### PR TITLE
Minor correction - removed special characters within code example

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -116,7 +116,7 @@ class Browser(DynamicCore):
     Pages and browser tabs are the same.
 
     Typical usage could be:
-    | *** Test Cases ***
+    | *** Test Cases ***
     | Starting a browser with a page
     |     New Browser    chromium    headless=false
     |     New Context    viewport={'width': 1920, 'height': 1080}


### PR DESCRIPTION
Fixes an issue under the "Pages" section
![image](https://user-images.githubusercontent.com/993527/93485259-e2ca0d80-f8d0-11ea-8282-fce9b76773ec.png)
It looks like the top part of the example, *** TestCases *, is outside of the code block and truncated.