### PR TITLE
Topic/pause on failure

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import os
-import sys
 import re
+import sys
 from concurrent.futures._base import Future
 from typing import List, Set
 
@@ -662,7 +662,9 @@ class Browser(DynamicCore):
         except AssertionError as e:
             self.keyword_error()
             if self._pause_on_failure:
-                sys.__stdout__.write("\n[Paused on failure] Press Enter to continue..\n")
+                sys.__stdout__.write(
+                    "\n[Paused on failure] Press Enter to continue..\n"
+                )
                 sys.__stdout__.flush()
                 input()
             raise e

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import sys
 import re
 from concurrent.futures._base import Future
 from typing import List, Set
@@ -661,7 +662,9 @@ class Browser(DynamicCore):
         except AssertionError as e:
             self.keyword_error()
             if self._pause_on_failure:
-                input("Press Enter to continue...")
+                sys.__stdout__.write("\n[Paused on failure] Press Enter to continue..\n")
+                sys.__stdout__.flush()
+                input()
             raise e
 
     def start_keyword(self, name, attrs):

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -523,6 +523,7 @@ class Browser(DynamicCore):
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
     SUPPORTED_BROWSERS = ["chromium", "firefox", "webkit"]
     _auto_closing_level: AutoClosingLevel
+    _pause_on_failure = False
 
     def __init__(
         self,
@@ -559,6 +560,7 @@ class Browser(DynamicCore):
         self.ROBOT_LIBRARY_LISTENER = self
         self._execution_stack: List[object] = []
         self._running_on_failure_keyword = False
+        self._pause_on_failure = False
         self.run_on_failure_keyword = (
             None if is_falsy(run_on_failure) else run_on_failure
         )
@@ -658,6 +660,8 @@ class Browser(DynamicCore):
             return DynamicCore.run_keyword(self, name, args, kwargs)
         except AssertionError as e:
             self.keyword_error()
+            if self._pause_on_failure:
+                input("Press Enter to continue...")
             raise e
 
     def start_keyword(self, name, attrs):

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -56,6 +56,7 @@ class PlaywrightState(LibraryComponent):
         url: Optional[str] = None,
         browser: SupportedBrowsers = SupportedBrowsers.chromium,
         headless: bool = False,
+        pauseOnFailure: bool = True,
     ):
         """Opens a new browser instance. Use this keyword for quick experiments or debugging sessions.
         Use `New Page` directly instead of `Open Browser` for production and automated execution.
@@ -74,11 +75,14 @@ class PlaywrightState(LibraryComponent):
         | webkit          | [https://webkit.org/|webkit]                         |
 
         ``headless`` <bool> If set to False, a GUI is provided otherwise it is hidden. Defaults to False.
+
+        ``pauseOnFailure`` <bool> Stop execution when failure detected and leave browser open. Defaults to True.
         """
 
         self.new_browser(browser, headless=headless)
         self.new_context()
         self.new_page(url)
+        self.library._pause_on_failure = pauseOnFailure
 
     @keyword(tags=["Setter", "BrowserControl"])
     def close_browser(self, browser: str = "CURRENT"):

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -78,7 +78,6 @@ class PlaywrightState(LibraryComponent):
 
         ``pauseOnFailure`` <bool> Stop execution when failure detected and leave browser open. Defaults to True.
         """
-
         self.new_browser(browser, headless=headless)
         self.new_context()
         self.new_page(url)

--- a/utest/test_development_functionality.py
+++ b/utest/test_development_functionality.py
@@ -1,0 +1,17 @@
+from Browser.keywords.playwright_state import PlaywrightState
+
+
+def test_pause_on_failure():
+    def whole_lib():
+        pass
+    whole_lib._pause_on_failure = False
+    whole_lib.playwright = whole_lib
+    browser = PlaywrightState(whole_lib)
+
+    def func(*args, **kwargs):
+        pass
+    browser.new_browser = func
+    browser.new_context = func
+    browser.new_page = func
+    browser.open_browser()
+    assert whole_lib._pause_on_failure


### PR DESCRIPTION
- leave everything open and paused when failure happens after `Open Browser`
- default to *True*

Strong opinion about Open Browser being for development.