### PR TITLE
Add option to specify browser path at import time

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -17,7 +17,7 @@ import re
 import sys
 from concurrent.futures._base import Future
 from datetime import timedelta
-from typing import List, Set, Union
+from typing import List, Optional, Set, Tuple, Union
 
 from robot.libraries.BuiltIn import EXECUTION_CONTEXTS, BuiltIn  # type: ignore
 from robot.utils import secs_to_timestr, timestr_to_secs  # type: ignore
@@ -40,6 +40,9 @@ from .keywords import (
 )
 from .playwright import Playwright
 from .utils import AutoClosingLevel, is_falsy, is_same_keyword, logger
+
+# Importing this directly from .utils break the stub type checks
+from .utils.data_types import SupportedBrowsers
 from .version import __version__ as VERSION
 
 
@@ -539,6 +542,7 @@ class Browser(DynamicCore):
         auto_closing_level: AutoClosingLevel = AutoClosingLevel.TEST,
         retry_assertions_for: timedelta = timedelta(seconds=1),
         run_on_failure: str = "Take Screenshot",
+        external_browser_executable: Optional[Tuple[SupportedBrowsers, str]] = None,
     ):
         """Browser library can be taken into use with optional arguments:
 
@@ -561,6 +565,9 @@ class Browser(DynamicCore):
           Sets the keyword to execute in case of a failing Browser keyword.
           It can be the name of any keyword that does not have any mandatory argument.
           If no extra action should be done after a failure, set it to ``None`` or any other robot falsy value.
+        - ``external_browser_executable`` <tuple <SupportedBrowsers, Optional<Path>>
+          Name and path to executable of a supported browser.
+          Will make opening new browsers of the given type use the set executablePath.
         """
         self.timeout = self.convert_timeout(timeout)
         self.retry_assertions_for = self.convert_timeout(retry_assertions_for)
@@ -571,6 +578,7 @@ class Browser(DynamicCore):
         self.run_on_failure_keyword = (
             None if is_falsy(run_on_failure) else run_on_failure
         )
+        self.external_browser_executable = external_browser_executable
         self._unresolved_promises: Set[Future] = set()
         self._playwright_state = PlaywrightState(self)
         libraries = [

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -17,7 +17,7 @@ import re
 import sys
 from concurrent.futures._base import Future
 from datetime import timedelta
-from typing import List, Optional, Set, Tuple, Union
+from typing import Dict, List, Set, Union
 
 from robot.libraries.BuiltIn import EXECUTION_CONTEXTS, BuiltIn  # type: ignore
 from robot.utils import secs_to_timestr, timestr_to_secs  # type: ignore
@@ -542,7 +542,7 @@ class Browser(DynamicCore):
         auto_closing_level: AutoClosingLevel = AutoClosingLevel.TEST,
         retry_assertions_for: timedelta = timedelta(seconds=1),
         run_on_failure: str = "Take Screenshot",
-        external_browser_executable: Optional[Tuple[SupportedBrowsers, str]] = None,
+        external_browser_executable: Dict[SupportedBrowsers, str] = {},
     ):
         """Browser library can be taken into use with optional arguments:
 
@@ -565,8 +565,8 @@ class Browser(DynamicCore):
           Sets the keyword to execute in case of a failing Browser keyword.
           It can be the name of any keyword that does not have any mandatory argument.
           If no extra action should be done after a failure, set it to ``None`` or any other robot falsy value.
-        - ``external_browser_executable`` <tuple <SupportedBrowsers, Optional<Path>>
-          Name and path to executable of a supported browser.
+        - ``external_browser_executable`` <Dict <SupportedBrowsers, Path>>
+          Dict mapping name of browser to path of executable of a browser.
           Will make opening new browsers of the given type use the set executablePath.
         """
         self.timeout = self.convert_timeout(timeout)
@@ -578,7 +578,9 @@ class Browser(DynamicCore):
         self.run_on_failure_keyword = (
             None if is_falsy(run_on_failure) else run_on_failure
         )
-        self.external_browser_executable = external_browser_executable
+        self.external_browser_executable: Dict[
+            SupportedBrowsers, str
+        ] = external_browser_executable
         self._unresolved_promises: Set[Future] = set()
         self._playwright_state = PlaywrightState(self)
         libraries = [

--- a/Browser/entry.py
+++ b/Browser/entry.py
@@ -23,6 +23,9 @@ USAGE = """USAGE
   rf-browser [command]
 AVAILABLE COMMANDS
   init  Install required nodejs dependencies
+    OPTIONS:
+        --skip-browsers
+
 """
 
 
@@ -32,13 +35,14 @@ def run():
         sys.exit(1)
     cmd = sys.argv[1]
     if cmd == "init":
-        rfbrowser_init()
+        arg2 = sys.argv[2] if len(sys.argv) >= 3 else ""
+        rfbrowser_init(arg2 == "--skip-browsers")
     else:
         print(f"Invalid command `{cmd}`")
         print(USAGE)
 
 
-def rfbrowser_init():
+def rfbrowser_init(skip_browser_install):
     print("Installing node dependencies...")
     installation_dir = Path(__file__).parent / "wrapper"
 
@@ -70,18 +74,26 @@ def rfbrowser_init():
         )
         sys.exit(exception)
 
+    env_copy = os.environ.copy()
+    if skip_browser_install:
+        env_copy["PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD"] = "1"
+
     process = Popen(
         "npm install --production",
         shell=True,
         cwd=installation_dir,
         stdout=PIPE,
         stderr=STDOUT,
+        env=env_copy,
     )
 
     for line in process.stdout:
         print(line.decode("utf-8"))
+    while process.poll() is None:
+        output = process.stdout.readline()
+        print(output.strip())
 
-    if process.returncode is not None:
+    if process.returncode != 0:
         raise RuntimeError(
             "Problem installing node dependencies."
             + f"Node process returned with exit status {process.returncode}"

--- a/Browser/gen_stub.py
+++ b/Browser/gen_stub.py
@@ -129,8 +129,8 @@ with open("Browser/__init__.pyi", "w") as stub_file:
     # init methods argument types that are contained within higher order types don't get
     # import syntax stripped correctly so we fix them manually here
     init_string = init_string.replace(
-        "Optional[Tuple[Browser.utils.data_types.SupportedBrowsers, str]]",
-        "Optional[Tuple[SupportedBrowsers, str]]",
+        "Dict[Browser.utils.data_types.SupportedBrowsers, str]",
+        "Dict[SupportedBrowsers, str]",
     )
 
     stub_file.write(init_string)

--- a/Browser/gen_stub.py
+++ b/Browser/gen_stub.py
@@ -103,6 +103,7 @@ from typing import (
     List,
     Optional,
     Union,
+    Tuple,
 )
 
 from .utils.data_types import *

--- a/Browser/gen_stub.py
+++ b/Browser/gen_stub.py
@@ -61,7 +61,7 @@ def get_function_list_from_keywords(keywords):
     return functions
 
 
-def keyword_line(keyword_arguments, keyword_types, method_name):
+def keyword_line(keyword_arguments, keyword_types, method_name) -> str:
     arguments_list = list()
     for argument in keyword_arguments:
         if isinstance(argument, tuple):
@@ -123,10 +123,16 @@ pyi_non_kw_methods = """\
 init_method = KeywordBuilder.build(br.__init__)
 with open("Browser/__init__.pyi", "w") as stub_file:
     stub_file.write(pyi_boilerplate)
-    stub_file.write(
-        keyword_line(
-            init_method.argument_specification, init_method.argument_types, "__init__"
-        )
+    init_string = keyword_line(
+        init_method.argument_specification, init_method.argument_types, "__init__"
     )
+    # init methods argument types that are contained within higher order types don't get
+    # import syntax stripped correctly so we fix them manually here
+    init_string = init_string.replace(
+        "Optional[Tuple[Browser.utils.data_types.SupportedBrowsers, str]]",
+        "Optional[Tuple[SupportedBrowsers, str]]",
+    )
+
+    stub_file.write(init_string)
     stub_file.writelines(function_list)
     stub_file.write(pyi_non_kw_methods)

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -300,11 +300,10 @@ class PlaywrightState(LibraryComponent):
         if timeout:
             params["timeout"] = self.convert_timeout(timeout)
         params["slowMo"] = self.convert_timeout(slowMo)
-        if (
-            self.library.external_browser_executable
-            and browser.name == self.library.external_browser_executable[0]
-        ):
-            params["executablePath"] = self.library.external_browser_executable[1]
+
+        browser_path = self.library.external_browser_executable.get(browser)
+        if browser_path:
+            params["executablePath"] = browser_path
 
         options = json.dumps(params, default=str)
         logger.info(options)

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -300,11 +300,16 @@ class PlaywrightState(LibraryComponent):
         if timeout:
             params["timeout"] = self.convert_timeout(timeout)
         params["slowMo"] = self.convert_timeout(slowMo)
+        if (
+            self.library.external_browser_executable
+            and browser.name == self.library.external_browser_executable[0]
+        ):
+            params["executablePath"] = self.library.external_browser_executable[1]
+
         options = json.dumps(params, default=str)
         logger.info(options)
 
         with self.playwright.grpc_channel() as stub:
-
             response = stub.NewBrowser(
                 Request().Browser(browser=browser.name, rawOptions=options)
             )

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.2.7",
     "pino": "^6.4.1",
+    "playwright": "^1.6.2",
     "prettier": "^2.0.5",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
@@ -39,7 +40,6 @@
     "@grpc/grpc-js": "^1.1.7",
     "@types/uuid": "^8.3.0",
     "google-protobuf": "3.13.0",
-    "playwright": "^1.5.1",
     "uuid": "^8.3.1"
   },
   "husky": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4646,10 +4646,10 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-playwright@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.5.1.tgz#f5333cbfefaf9cb7213b0c9ca8bc9f3f18efcf16"
-  integrity sha512-FYxrQ2TAmvp5ZnBnc6EJHc1Vt3DmXx8xVDq6rxVVG4YVoNKHYMarHI92zGyDlueN2kKCavrhk4Et9w6jJ5XWaA==
+playwright@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.6.2.tgz#8631aec4d16b081d8ac414637b006099814a69d1"
+  integrity sha512-KiMmQuANG4O/ozpwxP8EwBBap0/liS3+wwkGo6nBJ4O4951y4ZsRPR1dqwsMOUD9wjsWf3ER+bAmQH5XmEO4Ig==
   dependencies:
     debug "^4.1.1"
     extract-zip "^2.0.1"


### PR DESCRIPTION
``` ~/C/robotframework-browser (master)> cat playwright-log.txt
{"level":30,"time":"2020-11-17T15:37:18.666Z","pid":85462,"hostname":"robomb.local","msg":"Listening on 59453"}
2020-11-17T15:37:18.747Z pw:api => browserType.launch started
2020-11-17T15:37:18.765Z pw:api <= browserType.launch failed
================= Original suppressed error =================
browserType.launch: Failed to launch chromium because executable doesn't exist at /Users/kerkko/Library/Caches/ms-playwright/chromium-823944/chrome-mac/Chromium.app/Contents/MacOS/Chromium
Try re-installing playwright with "npm install playwright"
Note: use DEBUG=pw:api environment variable and rerun to capture Playwright logs.
    at Connection.sendMessageToServer (/Users/kerkko/Code/robotframework-browser/node_modules/playwright/lib/client/connection.js:69:15)
    at Proxy.<anonymous> (/Users/kerkko/Code/robotframework-browser/node_modules/playwright/lib/client/channelOwner.js:54:53)
    at /Users/kerkko/Code/robotframework-browser/node_modules/playwright/lib/client/browserType.js:61:73
    at BrowserType._wrapApiCall (/Users/kerkko/Code/robotframework-browser/node_modules/playwright/lib/client/channelOwner.js:80:34)
    at BrowserType.launch (/Users/kerkko/Code/robotframework-browser/node_modules/playwright/lib/client/browserType.js:52:21)
    at /Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:13450:64
    at step (/Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:13418:23)
    at Object.next (/Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:13399:53)
    at /Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:13393:71
    at new Promise (<anonymous>)
=============================================================
================= Original suppressed error =================
Error: Tried to take screenshot, but no page was open.
    at Object.exists (/Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:13327:15)
    at Object.<anonymous> (/Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:214:41)
    at step (/Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:142:23)
    at Object.next (/Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:123:53)
    at /Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:117:71
    at new Promise (<anonymous>)
    at ./node/playwright-wrapper/browser-control.ts.__awaiter (/Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:113:12)
    at Object.takeScreenshot (/Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:195:12)
    at PlaywrightServer.<anonymous> (/Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:11071:61)
    at step (/Users/kerkko/Code/robotframework-browser/Browser/wrapper/index.js:10630:23)
=============================================================
```
Even though the options seems to leave the python side correctly weirdly it doesn't have an effect at the Playwright side.

Closes #509