### PR TITLE
Add linting for from __future__ import annotations

### DIFF
--- a/Browser/.flake8
+++ b/Browser/.flake8
@@ -2,4 +2,5 @@
 exclude =
    __pycache__,
    generated,
-ignore = E501, W503
+ignore = E501, W503, FI10,FI11,FI12,FI13,FI14,FI15,FI16,FI17, FI58
+require-code = True

--- a/Browser/__init__.py
+++ b/Browser/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from .browser import Browser
 from .utils.data_types import (
     AssertionOperator,

--- a/Browser/assertion_engine.py
+++ b/Browser/assertion_engine.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import ast
 import re
 import time

--- a/Browser/base/__init__.py
+++ b/Browser/base/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 from Browser.base.cache import ContextCache  # noqa
 from Browser.base.librarycomponent import LibraryComponent  # noqa

--- a/Browser/base/cache.py
+++ b/Browser/base/cache.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+
+
 class ContextCache:
     def __init__(self):
         self.cache = {}

--- a/Browser/base/librarycomponent.py
+++ b/Browser/base/librarycomponent.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 from concurrent.futures._base import Future
 from datetime import timedelta

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import re
 import sys

--- a/Browser/dev-requirements.txt
+++ b/Browser/dev-requirements.txt
@@ -5,6 +5,7 @@ black >= 20.8b1
 mypy >= 0.782
 mypy-protobuf >= 1.23
 flake8 >= 3.8.3
+flake8-future-import >= 0.4.6
 isort >= 5.4.2
 wheel>=0.35.1
 robotframework-pabot >= 1.10.0

--- a/Browser/entry.py
+++ b/Browser/entry.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 import platform
 import subprocess

--- a/Browser/gen_stub.py
+++ b/Browser/gen_stub.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 from datetime import timedelta
 from typing import Any
 

--- a/Browser/keywords/__init__.py
+++ b/Browser/keywords/__init__.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from .browser_control import Control
 from .cookie import Cookie
 from .device_descriptors import Devices

--- a/Browser/keywords/browser_control.py
+++ b/Browser/keywords/browser_control.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import base64
 import json
 from datetime import timedelta

--- a/Browser/keywords/cookie.py
+++ b/Browser/keywords/cookie.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 from datetime import datetime
 from typing import List, Optional, Union

--- a/Browser/keywords/device_descriptors.py
+++ b/Browser/keywords/device_descriptors.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 from typing import Dict
 

--- a/Browser/keywords/evaluation.py
+++ b/Browser/keywords/evaluation.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 from datetime import timedelta
 from typing import Any

--- a/Browser/keywords/getters.py
+++ b/Browser/keywords/getters.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 from typing import Any, List, Optional, Union
 

--- a/Browser/keywords/interaction.py
+++ b/Browser/keywords/interaction.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 import os
 from datetime import timedelta

--- a/Browser/keywords/network.py
+++ b/Browser/keywords/network.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 from datetime import timedelta
 from typing import Any, Dict, Optional

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 from datetime import timedelta
 from typing import Any, Dict, List, Optional

--- a/Browser/keywords/promises.py
+++ b/Browser/keywords/promises.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from concurrent.futures import Future, ThreadPoolExecutor
 
 from robot.api.deco import keyword  # type: ignore

--- a/Browser/keywords/runonfailure.py
+++ b/Browser/keywords/runonfailure.py
@@ -18,6 +18,7 @@
 # modified my René Rohner under
 # Copyright 2020-     Robot Framework Foundation
 
+from __future__ import annotations
 
 from typing import Optional
 

--- a/Browser/keywords/waiter.py
+++ b/Browser/keywords/waiter.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 from datetime import timedelta
 from pathlib import Path

--- a/Browser/keywords/webapp_state.py
+++ b/Browser/keywords/webapp_state.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import json
 from typing import Any, Optional
 

--- a/Browser/locators/__init__.py
+++ b/Browser/locators/__init__.py
@@ -12,4 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from .locatorparse import LocatorParse  # noqa: F401

--- a/Browser/locators/locatorparse.py
+++ b/Browser/locators/locatorparse.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 # Derived from https://github.com/robotframework/SeleniumLibrary and modified by Tatu Aalto
+from __future__ import annotations
 
 import re
 from typing import List

--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import contextlib
 import os
 import time

--- a/Browser/sorted_execution_time_logs.py
+++ b/Browser/sorted_execution_time_logs.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 
 """ Sorts and prints in descending order by duration function call

--- a/Browser/utils/__init__.py
+++ b/Browser/utils/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # flake8: noqa
+from __future__ import annotations
 
 from .data_types import (
     AssertionOperator,

--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from enum import Enum, auto
 from typing import Dict, Union
 

--- a/Browser/utils/js_utilities.py
+++ b/Browser/utils/js_utilities.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import re
 from typing import Any, Optional
 

--- a/Browser/utils/logger.py
+++ b/Browser/utils/logger.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import threading
 from typing import Any, Callable, Dict, List
 

--- a/Browser/utils/meta_python.py
+++ b/Browser/utils/meta_python.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 from enum import Enum
 from typing import Dict, List, TypeVar
 

--- a/Browser/utils/misc.py
+++ b/Browser/utils/misc.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import contextlib
 import inspect
 import socket

--- a/Browser/utils/robot_booleans.py
+++ b/Browser/utils/robot_booleans.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from typing import Any
 
 TRUE_STRINGS = {"TRUE", "YES", "ON", "1", "CHECKED"}

--- a/Browser/version.py
+++ b/Browser/version.py
@@ -1,1 +1,3 @@
+from __future__ import annotations
+
 __version__ = "2.2.0"

--- a/utest/test_assertion_engine.py
+++ b/utest/test_assertion_engine.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 from approvaltests import verify_all  # type: ignore
 
@@ -14,7 +15,6 @@ def test_equals():
         _validate_operator(AssertionOperator["=="], "actual", "actual"),
         _validate_operator(AssertionOperator["=="], "actual", "unexpected"),
         _validate_operator(AssertionOperator["=="], 1, "1"),
-
     ]
     verify_all("Test equals", results)
 
@@ -69,7 +69,7 @@ def test_without_assertions_polling():
     results = [
         fb.is_three(3),
         _method_validator(fb.is_three, 2),
-        _method_validator(fb.second_run_success)
+        _method_validator(fb.second_run_success),
     ]
     verify_all("No polling", results)
 
@@ -115,9 +115,12 @@ def test_match():
         _validate_operator(AssertionOperator["matches"], "Actual", "^Act"),
         _validate_operator(AssertionOperator["matches"], "Actual", "/(\\d)+/"),
         _validate_operator(AssertionOperator["matches"], "Actual", "ual$"),
-        _validate_operator(AssertionOperator["matches"], "Actual\nmultiline", "(?m)Actual\nmultiline$"),
-        _validate_operator(AssertionOperator["matches"], "Actual\nmultiline", "/(\\d)+/"),
-
+        _validate_operator(
+            AssertionOperator["matches"], "Actual\nmultiline", "(?m)Actual\nmultiline$"
+        ),
+        _validate_operator(
+            AssertionOperator["matches"], "Actual\nmultiline", "/(\\d)+/"
+        ),
     ]
     verify_all("match", results)
 
@@ -148,7 +151,7 @@ def test_then(with_suite):
     results = [
         verify_assertion(8, then_op, "value + 3") == 11,
         verify_assertion(2, then_op, "value + 3") == 5,
-        verify_assertion("René", then_op, "'Hello ' + value + '!'") == "Hello René!"
+        verify_assertion("René", then_op, "'Hello ' + value + '!'") == "Hello René!",
     ]
     verify_all("then", results)
 
@@ -157,11 +160,16 @@ def test_start_with():
     results = [
         _validate_operator(AssertionOperator["^="], "Hello Robots", "Hello"),
         _validate_operator(AssertionOperator["^="], "Hello Robots", "Robots"),
-        _validate_operator(AssertionOperator["should start with"], "Hello Robots", "Hello"),
-        _validate_operator(AssertionOperator["should start with"], "Hello Robots", "Robots"),
-        _validate_operator(AssertionOperator["^="], "Hel[4,5]?[1-9]+ Robots", "Hel[4,5]?[1-"),
+        _validate_operator(
+            AssertionOperator["should start with"], "Hello Robots", "Hello"
+        ),
+        _validate_operator(
+            AssertionOperator["should start with"], "Hello Robots", "Robots"
+        ),
+        _validate_operator(
+            AssertionOperator["^="], "Hel[4,5]?[1-9]+ Robots", "Hel[4,5]?[1-"
+        ),
         _validate_operator(AssertionOperator["^="], "Hel[4,5]?[1-9]+ Robots", ".*"),
-
     ]
     verify_all("start with", results)
 
@@ -170,7 +178,9 @@ def test_ends_with():
     results = [
         _validate_operator(AssertionOperator["$="], "Hello Robots", "Robots"),
         _validate_operator(AssertionOperator["$="], "Hello Robots", "Hello"),
-        _validate_operator(AssertionOperator["$="], "Hel[4,5]?[1-9]+ Robots", "[1-9]+ Robots"),
+        _validate_operator(
+            AssertionOperator["$="], "Hel[4,5]?[1-9]+ Robots", "[1-9]+ Robots"
+        ),
         _validate_operator(AssertionOperator["$="], "Hel[4,5]?[1-9]+ Robots", ".*"),
     ]
     verify_all("ends with", results)

--- a/utest/test_context_cache.py
+++ b/utest/test_context_cache.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import json
 
 import pytest

--- a/utest/test_cookie.py
+++ b/utest/test_cookie.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import sys
 from datetime import datetime
 

--- a/utest/test_development_functionality.py
+++ b/utest/test_development_functionality.py
@@ -1,15 +1,18 @@
+from __future__ import annotations
 from Browser.keywords.playwright_state import PlaywrightState
 
 
 def test_pause_on_failure():
     def whole_lib():
         pass
+
     whole_lib._pause_on_failure = set()
     whole_lib.playwright = whole_lib
     browser = PlaywrightState(whole_lib)
 
     def func(*args, **kwargs):
         pass
+
     browser.new_browser = func
     browser.new_context = func
     browser.new_page = func

--- a/utest/test_docs.py
+++ b/utest/test_docs.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import Browser
 
 

--- a/utest/test_format_cookie.py
+++ b/utest/test_format_cookie.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from datetime import datetime
 
 import pytest

--- a/utest/test_get_time.py
+++ b/utest/test_get_time.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from datetime import timedelta
 
 import pytest

--- a/utest/test_get_video_size.py
+++ b/utest/test_get_video_size.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 from approvaltests import verify_all  # type: ignore
 
@@ -15,6 +16,11 @@ def test_get_video_size(state: PlaywrightState):
         state._get_video_size({"videosPath": "/path/to"}),
         state._get_video_size({"videoSize": {"width": 12, "height": 11}}),
         state._get_video_size({"viewport": {"width": 123, "height": 111}}),
-        state._get_video_size({"videoSize": {"width": 12, "height": 11}, "viewport": {"width": 123, "height": 111}})
+        state._get_video_size(
+            {
+                "videoSize": {"width": 12, "height": 11},
+                "viewport": {"width": 123, "height": 111},
+            }
+        ),
     ]
     verify_all("Video size", results)

--- a/utest/test_locator_parse.py
+++ b/utest/test_locator_parse.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 
 from Browser.locators import LocatorParse

--- a/utest/test_python_usage.py
+++ b/utest/test_python_usage.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import pytest
 import subprocess
 

--- a/utest/test_secrets.py
+++ b/utest/test_secrets.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
 import Browser.keywords.interaction as interaction
 
 
 def test_fill_or_type_secret_in_plain_text_logs_warning():
     def whole_lib():
         pass
+
     whole_lib.current_arguments = False
 
     class MyLogger:
@@ -14,15 +16,18 @@ def test_fill_or_type_secret_in_plain_text_logs_warning():
             self.message = message
 
     interaction.logger = MyLogger()
-    interaction.get_variable_value = lambda *args: 'value'
+    interaction.get_variable_value = lambda *args: "value"
 
     browser = interaction.Interaction(whole_lib)
     browser._fill_text = lambda selector, secret, log_response=False: 0
     browser._type_text = lambda selector, secret, delay, clear, log_response=False: 0
 
     browser.fill_secret("selector", "my secret in plain text")
-    assert interaction.logger.message == "Direct assignment of values as 'secret' is deprecated.Use variables or " \
-                                         "environment variables instead."
+    assert (
+        interaction.logger.message
+        == "Direct assignment of values as 'secret' is deprecated.Use variables or "
+        "environment variables instead."
+    )
     interaction.logger = MyLogger()
     browser.fill_secret("selector", "$variable")
     assert interaction.logger.message is None
@@ -33,5 +38,8 @@ def test_fill_or_type_secret_in_plain_text_logs_warning():
 
     interaction.logger = MyLogger()
     browser.type_secret("selector", "my secret in plain text")
-    assert interaction.logger.message == "Direct assignment of values as 'secret' is deprecated.Use variables or " \
-                                         "environment variables instead."
+    assert (
+        interaction.logger.message
+        == "Direct assignment of values as 'secret' is deprecated.Use variables or "
+        "environment variables instead."
+    )

--- a/utest/test_type_converter.py
+++ b/utest/test_type_converter.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 from approvaltests import verify_all  # type: ignore
 
 from Browser.utils.misc import type_converter


### PR DESCRIPTION
This `__future__` behaviour will be made mandatory in 3.10, and for packages wanting to support both older pythons and 3.10  at the same time using this is best practice.

The changed behaviour relates to later evaluation of type annotations, so for fixing the test failures work in gen_type_stubs, robot core or pythonlibcore might be necessary as well as work on our end. https://www.python.org/dev/peps/pep-0563/