### PR TITLE
Argparse and rfbrowser settings saving

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -603,6 +603,10 @@ class Browser(DynamicCore):
         - ``jsextension`` <str>
           Path to Javascript module exposed as extra keywords. Module must be in CommonJS.
         """
+        settings_path = Path(installation_dir / "settings.json")
+        if settings_path.is_file():
+            with open(settings_path, "r") as f:
+                settings = json.load(f)
         self.timeout = self.convert_timeout(timeout)
         self.retry_assertions_for = self.convert_timeout(retry_assertions_for)
         self.ROBOT_LIBRARY_LISTENER = self


### PR DESCRIPTION
Use argparse for CLI parsing, start adding support to save settings of rfbrowser init into file.

This enables installs where for example browser location is customzied at install time, without user needing to re-specify them at every import site.

TODO: 
- [ ] Get installation Path correctly in Browser/browser.py or abstract it into some other module.
- [ ] Enable flows like `rfbrowser init --browser=chromium` 
- [ ] Enable usage like `rfbrowser init --external-browser-executable=/chromium-path`