### PR TITLE
Add Node version limitation hint to the installation notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [keyword documentation](https://marketsquare.github.io/robotframework-browse
 
 Only Python 3.7 or newer is supported.
 
-1. Install node.js e.g. from https://nodejs.org/en/download/
+1. Install node.js e.g. from https://nodejs.org/en/download/ (only < v15 supported; if unsure, use 14.15.0 LTS)
 2. Install robotframework-browser from the commandline: `pip install robotframework-browser`
 3. Install the node dependencies: run `rfbrowser init` in your shell
   - if `rfbrowser` is not found, try `python -m Browser.entry init


### PR DESCRIPTION
Installation of Browser fails (and is not supported currently) on Node.JS version >= 15. 

This was already [discussed on Slack](https://robotframework.slack.com/archives/C015KB1QSDN/p1608043930266600). 

Please add this important fact to the installation instructions of browser.   