### PR TITLE
Topic/page listeners

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -26,6 +26,8 @@ from typing import Dict, List, Optional, Set, Union
 from assertionengine import AssertionOperator
 from robot.libraries.BuiltIn import EXECUTION_CONTEXTS, BuiltIn  # type: ignore
 from robot.utils import secs_to_timestr, timestr_to_secs  # type: ignore
+from robot.result.model import TestCase as TestCaseResult  # type: ignore
+from robot.running.model import TestCase as TestCaseRunning  # type: ignore
 from robotlibcore import DynamicCore  # type: ignore
 
 from .base import ContextCache, LibraryComponent
@@ -744,7 +746,7 @@ class Browser(DynamicCore):
             except ConnectionError as e:
                 logger.debug(f"Browser._start_test connection problem: {e}")
 
-    def _end_test(self, test, result):
+    def _end_test(self, test: TestCaseRunning, result: TestCaseResult):
         if len(self._unresolved_promises) > 0:
             logger.warn(f"Waiting unresolved promises at the end of test '{test.name}'")
             self.wait_for_all_promises()
@@ -762,6 +764,7 @@ class Browser(DynamicCore):
                 logger.debug(f"Test Case: {test.name}, End Test: {e}")
             except ConnectionError as e:
                 logger.debug(f"Browser._end_test connection problem: {e}")
+
 
     def _end_suite(self, suite, result):
         if self._auto_closing_level != AutoClosingLevel.MANUAL:

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -25,9 +25,9 @@ from typing import Dict, List, Optional, Set, Union
 
 from assertionengine import AssertionOperator
 from robot.libraries.BuiltIn import EXECUTION_CONTEXTS, BuiltIn  # type: ignore
-from robot.utils import secs_to_timestr, timestr_to_secs  # type: ignore
 from robot.result.model import TestCase as TestCaseResult  # type: ignore
 from robot.running.model import TestCase as TestCaseRunning  # type: ignore
+from robot.utils import secs_to_timestr, timestr_to_secs  # type: ignore
 from robotlibcore import DynamicCore  # type: ignore
 
 from .base import ContextCache, LibraryComponent
@@ -653,7 +653,7 @@ class Browser(DynamicCore):
         self.timeout = self.convert_timeout(timeout)
         self.retry_assertions_for = self.convert_timeout(retry_assertions_for)
         self.ROBOT_LIBRARY_LISTENER = self
-        self._execution_stack: List[object] = []
+        self._execution_stack: List[dict] = []
         self._running_on_failure_keyword = False
         self._pause_on_failure = set()
         self.run_on_failure_keyword = (
@@ -764,7 +764,6 @@ class Browser(DynamicCore):
                 logger.debug(f"Test Case: {test.name}, End Test: {e}")
             except ConnectionError as e:
                 logger.debug(f"Browser._end_test connection problem: {e}")
-
 
     def _end_suite(self, suite, result):
         if self._auto_closing_level != AutoClosingLevel.MANUAL:

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -596,7 +596,7 @@ class Browser(DynamicCore):
     """
 
     ROBOT_LIBRARY_VERSION = VERSION
-    ROBOT_LISTENER_API_VERSION = 2
+    ROBOT_LISTENER_API_VERSION = 3
     ROBOT_LIBRARY_LISTENER: "Browser"
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
     SUPPORTED_BROWSERS = ["chromium", "firefox", "webkit"]
@@ -726,7 +726,7 @@ class Browser(DynamicCore):
         except ConnectionError as e:
             logger.trace(f"Browser library closing problem: {e}")
 
-    def _start_suite(self, name, attrs):
+    def _start_suite(self, suite, result):
         if not self._suite_cleanup_done and self.browser_output.is_dir():
             self._suite_cleanup_done = True
             logger.debug(f"Removing: {self.browser_output}")
@@ -737,16 +737,16 @@ class Browser(DynamicCore):
             except ConnectionError as e:
                 logger.debug(f"Browser._start_suite connection problem: {e}")
 
-    def _start_test(self, name, attrs):
+    def _start_test(self, test, result):
         if self._auto_closing_level == AutoClosingLevel.TEST:
             try:
                 self._execution_stack.append(self.get_browser_catalog())
             except ConnectionError as e:
                 logger.debug(f"Browser._start_test connection problem: {e}")
 
-    def _end_test(self, name, attrs):
+    def _end_test(self, test, result):
         if len(self._unresolved_promises) > 0:
-            logger.warn(f"Waiting unresolved promises at the end of test '{name}'")
+            logger.warn(f"Waiting unresolved promises at the end of test '{test.name}'")
             self.wait_for_all_promises()
         if self._auto_closing_level == AutoClosingLevel.TEST:
             if self.presenter_mode:
@@ -759,11 +759,11 @@ class Browser(DynamicCore):
                 catalog_before_test = self._execution_stack.pop()
                 self._prune_execution_stack(catalog_before_test)
             except AssertionError as e:
-                logger.debug(f"Test Case: {name}, End Test: {e}")
+                logger.debug(f"Test Case: {test.name}, End Test: {e}")
             except ConnectionError as e:
                 logger.debug(f"Browser._end_test connection problem: {e}")
 
-    def _end_suite(self, name, attrs):
+    def _end_suite(self, suite, result):
         if self._auto_closing_level != AutoClosingLevel.MANUAL:
             if len(self._execution_stack) == 0:
                 logger.debug("Browser._end_suite empty execution stack")
@@ -772,7 +772,7 @@ class Browser(DynamicCore):
                 catalog_before_suite = self._execution_stack.pop()
                 self._prune_execution_stack(catalog_before_suite)
             except AssertionError as e:
-                logger.debug(f"Test Suite: {name}, End Suite: {e}")
+                logger.debug(f"Test Suite: {suite.name}, End Suite: {e}")
             except ConnectionError as e:
                 logger.debug(f"Browser._end_suite connection problem: {e}")
 

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -239,7 +239,7 @@ class PlaywrightState(LibraryComponent):
                         messages = json.loads(response.console)
                         if messages:
                             for message in messages:
-                                logger.console(f"console: {message}")
+                                logger.error(f"console: {message}")
 
     @keyword(tags=("Setter", "BrowserControl"))
     def connect_to_browser(

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -189,7 +189,10 @@ class PlaywrightState(LibraryComponent):
         ``browser`` < ``CURRENT`` | ``ALL`` | str > Id of the browser that belongs to the page to be closed.
         If ``ALL`` is passed, the requested pages depending of the context of all browsers are closed.
         Defaults to CURRENT.
+
+        Returns a list of dictionaries containing errors and console messages from the page.
         """
+        result = []
         with self.playwright.grpc_channel() as stub:
             catalog = self.library.get_browser_catalog()
 
@@ -232,14 +235,13 @@ class PlaywrightState(LibraryComponent):
                         response = stub.ClosePage(Request().Empty())
                         if response.log:
                             logger.info(response.log)
-                        errors = json.loads(response.errors)
-                        if errors:
-                            for error in errors:
-                                logger.error(f"Page error: {error}")
-                        messages = json.loads(response.console)
-                        if messages:
-                            for message in messages:
-                                logger.error(f"console: {message}")
+                        result.append(
+                            {
+                                "errors": json.loads(response.errors),
+                                "console": json.loads(response.console),
+                            }
+                        )
+        return result
 
     @keyword(tags=("Setter", "BrowserControl"))
     def connect_to_browser(

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -239,7 +239,7 @@ class PlaywrightState(LibraryComponent):
                             {
                                 "errors": json.loads(response.errors),
                                 "console": json.loads(response.console),
-                                "id": p,
+                                "id": response.pageId,
                             }
                         )
         return result

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -239,7 +239,7 @@ class PlaywrightState(LibraryComponent):
                             {
                                 "errors": json.loads(response.errors),
                                 "console": json.loads(response.console),
-                                "id": p
+                                "id": p,
                             }
                         )
         return result

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -241,7 +241,6 @@ class PlaywrightState(LibraryComponent):
                             for message in messages:
                                 logger.error(f"Console output: '{message}'")
 
-
     @keyword(tags=("Setter", "BrowserControl"))
     def connect_to_browser(
         self, wsEndpoint: str, browser: SupportedBrowsers = SupportedBrowsers.chromium

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -190,7 +190,7 @@ class PlaywrightState(LibraryComponent):
         If ``ALL`` is passed, the requested pages depending of the context of all browsers are closed.
         Defaults to CURRENT.
 
-        Returns a list of dictionaries containing errors and console messages from the page.
+        Returns a list of dictionaries containing id, errors and console messages from the page.
         """
         result = []
         with self.playwright.grpc_channel() as stub:
@@ -239,6 +239,7 @@ class PlaywrightState(LibraryComponent):
                             {
                                 "errors": json.loads(response.errors),
                                 "console": json.loads(response.console),
+                                "id": p
                             }
                         )
         return result

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -230,7 +230,17 @@ class PlaywrightState(LibraryComponent):
                         if page != "CURRENT":
                             self.switch_page(p)
                         response = stub.ClosePage(Request().Empty())
-                        logger.info(response.log)
+                        if response.log:
+                            logger.info(response.log)
+                        errors = json.loads(response.errors)
+                        if errors:
+                            for error in errors:
+                                logger.error(f"Error during page life: {error}")
+                        messages = json.loads(response.console)
+                        if messages:
+                            for message in messages:
+                                logger.error(f"Console output: '{message}'")
+
 
     @keyword(tags=("Setter", "BrowserControl"))
     def connect_to_browser(

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -235,11 +235,11 @@ class PlaywrightState(LibraryComponent):
                         errors = json.loads(response.errors)
                         if errors:
                             for error in errors:
-                                logger.error(f"Error during page life: {error}")
+                                logger.error(f"Page error: {error}")
                         messages = json.loads(response.console)
                         if messages:
                             for message in messages:
-                                logger.error(f"Console output: '{message}'")
+                                logger.console(f"console: {message}")
 
     @keyword(tags=("Setter", "BrowserControl"))
     def connect_to_browser(

--- a/atest/test/01_Browser_Management/playwright_state.robot
+++ b/atest/test/01_Browser_Management/playwright_state.robot
@@ -157,11 +157,12 @@ Page indices are unique
     Should Not Be Equal    ${first}    ${second}
 
 Close Page gets errors and console log
-    New Page    ${ERROR_URL}
+    ${id}=    New Page    ${ERROR_URL}
     Click    "Crash click"
     ${response}=    Close Page
     Should be equal    ${response}[0][console][0][text]    Hello from warning
     Should match    ${response}[0][errors][0]    Error: a is not defined*
+    Should be equal    ${response}[0][id]    ${id}
 
 Context indices are unique
     ${first}=    New Context
@@ -187,7 +188,8 @@ Close All Pages
     New Page
     New Page
     New Page
-    Close Page    ALL
+    ${closes}=    Close Page    ALL
+    Length Should Be    ${closes}    3
     ${current}=    Switch Page    CURRENT
     Should Be Equal    ${current}    NO PAGE OPEN
 

--- a/atest/test/01_Browser_Management/playwright_state.robot
+++ b/atest/test/01_Browser_Management/playwright_state.robot
@@ -156,6 +156,13 @@ Page indices are unique
     ${second}=    New Page
     Should Not Be Equal    ${first}    ${second}
 
+Close Page gets errors and console log
+    New Page    ${ERROR_URL}
+    Click    "Crash click"
+    ${response}=    Close Page
+    Should be equal    ${response}[0][console][0][text]    Hello from warning
+    Should match    ${response}[0][errors][0]    Error: a is not defined*
+
 Context indices are unique
     ${first}=    New Context
     Close Context

--- a/atest/test/01_Browser_Management/playwright_state.robot
+++ b/atest/test/01_Browser_Management/playwright_state.robot
@@ -160,6 +160,7 @@ Close Page gets errors and console log
     ${id}=    New Page    ${ERROR_URL}
     Click    "Crash click"
     ${response}=    Close Page
+    Log    ${response}
     Should be equal    ${response}[0][console][0][text]    Hello from warning
     Should match    ${response}[0][errors][0]    Error: a is not defined*
     Should be equal    ${response}[0][id]    ${id}

--- a/atest/test/01_Browser_Management/playwright_state.robot
+++ b/atest/test/01_Browser_Management/playwright_state.robot
@@ -188,7 +188,6 @@ Closing Page/Contex/Browser Multiple Times Should Not Cause Errors
     New Context
     New Page
     Close Page
-    Close Page
     Close Context
     Close Context
     Close Browser

--- a/node/dynamic-test-app/static/error.html
+++ b/node/dynamic-test-app/static/error.html
@@ -8,7 +8,11 @@
   <div id="container">
     <h1>Error Page</h1>
     <p>Login failed. Invalid user name and/or password.</p>
-    <button type="button" onclick="javascript:alert('your msg')";>Do not click!</button>
+    <button type="button" onclick="javascript:alert('your msg')">Do not click!</button>
+    <button type="button" onclick="javascript:a+1">Crash click</button>
   </div>
 </body>
+<script>
+  console.warn("Hello from warning");
+</script>
 </html>

--- a/node/playwright-wrapper/playwright-state.ts
+++ b/node/playwright-wrapper/playwright-state.ts
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 import * as playwright from 'playwright';
-import {Browser, BrowserContext, ElementHandle, Page, chromium, firefox, webkit, ConsoleMessage} from 'playwright';
+import { Browser, BrowserContext, ConsoleMessage, ElementHandle, Page, chromium, firefox, webkit } from 'playwright';
 import { v4 as uuidv4 } from 'uuid';
 
 import { Request, Response } from './generated/playwright_pb';
-import {emptyWithLog, jsonResponse, keywordsResponse, pageReportResponse, stringResponse} from './response-util';
+import { emptyWithLog, jsonResponse, keywordsResponse, pageReportResponse, stringResponse } from './response-util';
 import { exists } from './playwirght-invoke';
 
 import * as pino from 'pino';
@@ -132,7 +132,7 @@ function indexedPage(newPage: Page) {
         p: newPage,
         timestamp,
         pageErrors,
-        consoleMessages
+        consoleMessages,
     };
 }
 
@@ -390,8 +390,7 @@ export async function closePage(openBrowsers: PlaywrightState): Promise<Response
     const activeBrowser = openBrowsers.getActiveBrowser();
     await openBrowsers.getActivePage()?.close();
     const closedPage = activeBrowser.popPage();
-    if (!closedPage)
-        throw new Error("No open page");
+    if (!closedPage) throw new Error('No open page');
     return pageReportResponse('Successfully closed Page', closedPage);
 }
 

--- a/node/playwright-wrapper/playwright-state.ts
+++ b/node/playwright-wrapper/playwright-state.ts
@@ -17,7 +17,7 @@ import {Browser, BrowserContext, ElementHandle, Page, chromium, firefox, webkit,
 import { v4 as uuidv4 } from 'uuid';
 
 import { Request, Response } from './generated/playwright_pb';
-import { emptyWithLog, jsonResponse, keywordsResponse, stringResponse } from './response-util';
+import {emptyWithLog, jsonResponse, keywordsResponse, pageReportResponse, stringResponse} from './response-util';
 import { exists } from './playwirght-invoke';
 
 import * as pino from 'pino';
@@ -268,7 +268,7 @@ type IndexedContext = {
     options?: Record<string, unknown>;
 };
 
-type IndexedPage = {
+export type IndexedPage = {
     p: Page;
     id: Uuid;
     timestamp: number;
@@ -355,9 +355,9 @@ export class BrowserState {
     get contextStack(): IndexedContext[] {
         return this._contextStack;
     }
-    public popPage(): void {
+    public popPage(): IndexedPage | undefined {
         const pageStack = this.context?.pageStack || [];
-        pageStack.pop();
+        return pageStack.pop();
     }
     public popContext(): void {
         this._contextStack.pop();
@@ -386,11 +386,13 @@ export async function closeContext(openBrowsers: PlaywrightState): Promise<Respo
     return emptyWithLog('Successfully closed Context');
 }
 
-export async function closePage(openBrowsers: PlaywrightState): Promise<Response.Empty> {
+export async function closePage(openBrowsers: PlaywrightState): Promise<Response.PageReportResponse> {
     const activeBrowser = openBrowsers.getActiveBrowser();
     await openBrowsers.getActivePage()?.close();
-    activeBrowser.popPage();
-    return emptyWithLog('Successfully closed Page');
+    const closedPage = activeBrowser.popPage();
+    if (!closedPage)
+        throw new Error("No open page");
+    return pageReportResponse('Successfully closed Page', closedPage);
 }
 
 export async function newPage(request: Request.Url, openBrowsers: PlaywrightState): Promise<Response.NewPageResponse> {

--- a/node/playwright-wrapper/response-util.ts
+++ b/node/playwright-wrapper/response-util.ts
@@ -15,10 +15,19 @@
 import { Response } from './generated/playwright_pb';
 import { errors } from 'playwright';
 import { status } from '@grpc/grpc-js';
+import {IndexedPage} from "./playwright-state";
 
 export function emptyWithLog(text: string): Response.Empty {
     const response = new Response.Empty();
     response.setLog(text);
+    return response;
+}
+
+export function pageReportResponse(log: string, page: IndexedPage): Response.PageReportResponse {
+    const response = new Response.PageReportResponse();
+    response.setLog(log);
+    response.setConsole(JSON.stringify(page.consoleMessages.map(m => `${m.location().url} [${m.type()}]: ${m.text()}`)));
+    response.setErrors(JSON.stringify(page.pageErrors.map(e => e.message)));
     return response;
 }
 

--- a/node/playwright-wrapper/response-util.ts
+++ b/node/playwright-wrapper/response-util.ts
@@ -35,7 +35,9 @@ export function pageReportResponse(log: string, page: IndexedPage): Response.Pag
             })),
         ),
     );
-    response.setErrors(JSON.stringify(page.pageErrors.map((e) => `${e.name}: ${e.message}\n${e.stack}`)));
+    response.setErrors(
+        JSON.stringify(page.pageErrors.map((e) => (e ? `${e.name}: ${e.message}\n${e.stack}` : 'unknown error'))),
+    );
     return response;
 }
 

--- a/node/playwright-wrapper/response-util.ts
+++ b/node/playwright-wrapper/response-util.ts
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import {Response} from './generated/playwright_pb';
-import {errors} from 'playwright';
-import {status} from '@grpc/grpc-js';
-import {IndexedPage} from "./playwright-state";
+import { IndexedPage } from './playwright-state';
+import { Response } from './generated/playwright_pb';
+import { errors } from 'playwright';
+import { status } from '@grpc/grpc-js';
 
 export function emptyWithLog(text: string): Response.Empty {
     const response = new Response.Empty();
@@ -26,12 +26,16 @@ export function emptyWithLog(text: string): Response.Empty {
 export function pageReportResponse(log: string, page: IndexedPage): Response.PageReportResponse {
     const response = new Response.PageReportResponse();
     response.setLog(log);
-    response.setConsole(JSON.stringify(page.consoleMessages.map(m => ({
-        type: m.type(),
-        text: m.text(),
-        ...m.location()
-    }))));
-    response.setErrors(JSON.stringify(page.pageErrors.map(e => `${e.name}: ${e.message}\n${e.stack}`)));
+    response.setConsole(
+        JSON.stringify(
+            page.consoleMessages.map((m) => ({
+                type: m.type(),
+                text: m.text(),
+                ...m.location(),
+            })),
+        ),
+    );
+    response.setErrors(JSON.stringify(page.pageErrors.map((e) => `${e.name}: ${e.message}\n${e.stack}`)));
     return response;
 }
 
@@ -78,7 +82,7 @@ export function errorResponse(e: Error) {
     if (e instanceof errors.TimeoutError) {
         errorCode = status.DEADLINE_EXCEEDED;
     }
-    return {code: status.DEADLINE_EXCEEDED, message: errorMessage};
+    return { code: status.DEADLINE_EXCEEDED, message: errorMessage };
 }
 
 export function keywordsResponse(keywords: string[], logMessage: string) {

--- a/node/playwright-wrapper/response-util.ts
+++ b/node/playwright-wrapper/response-util.ts
@@ -38,6 +38,7 @@ export function pageReportResponse(log: string, page: IndexedPage): Response.Pag
     response.setErrors(
         JSON.stringify(page.pageErrors.map((e) => (e ? `${e.name}: ${e.message}\n${e.stack}` : 'unknown error'))),
     );
+    response.setPageid(page.id);
     return response;
 }
 

--- a/node/playwright-wrapper/response-util.ts
+++ b/node/playwright-wrapper/response-util.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { Response } from './generated/playwright_pb';
-import { errors } from 'playwright';
-import { status } from '@grpc/grpc-js';
+import {Response} from './generated/playwright_pb';
+import {errors} from 'playwright';
+import {status} from '@grpc/grpc-js';
 import {IndexedPage} from "./playwright-state";
 
 export function emptyWithLog(text: string): Response.Empty {
@@ -26,8 +26,12 @@ export function emptyWithLog(text: string): Response.Empty {
 export function pageReportResponse(log: string, page: IndexedPage): Response.PageReportResponse {
     const response = new Response.PageReportResponse();
     response.setLog(log);
-    response.setConsole(JSON.stringify(page.consoleMessages.map(m => `${m.location().url} [${m.type()}]: ${m.text()}`)));
-    response.setErrors(JSON.stringify(page.pageErrors.map(e => e.message)));
+    response.setConsole(JSON.stringify(page.consoleMessages.map(m => ({
+        type: m.type(),
+        text: m.text(),
+        ...m.location()
+    }))));
+    response.setErrors(JSON.stringify(page.pageErrors.map(e => `${e.name}: ${e.message}\n${e.stack}`)));
     return response;
 }
 
@@ -74,7 +78,7 @@ export function errorResponse(e: Error) {
     if (e instanceof errors.TimeoutError) {
         errorCode = status.DEADLINE_EXCEEDED;
     }
-    return { code: status.DEADLINE_EXCEEDED, message: errorMessage };
+    return {code: status.DEADLINE_EXCEEDED, message: errorMessage};
 }
 
 export function keywordsResponse(keywords: string[], logMessage: string) {

--- a/protobuf/playwright.proto
+++ b/protobuf/playwright.proto
@@ -247,6 +247,7 @@ message Response {
     string log = 1;
     string errors = 2;
     string console = 3;
+    string pageId = 4;
   }
 }
 

--- a/protobuf/playwright.proto
+++ b/protobuf/playwright.proto
@@ -242,6 +242,12 @@ message Response {
     string body = 2;
     string video = 3;
   }
+
+  message PageReportResponse {
+    string log = 1;
+    string errors = 2;
+    string console = 3;
+  }
 }
 
 service  Playwright {
@@ -364,7 +370,7 @@ service  Playwright {
   rpc CloseBrowser(Request.Empty) returns (Response.String);
   rpc CloseAllBrowsers(Request.Empty) returns (Response.Empty);
   rpc CloseContext(Request.Empty) returns (Response.Empty);
-  rpc ClosePage(Request.Empty) returns (Response.Empty);
+  rpc ClosePage(Request.Empty) returns (Response.PageReportResponse);
   rpc GetBrowserCatalog(Request.Empty) returns (Response.Json);
 
   /* Extension handling */


### PR DESCRIPTION
Recording page errors and console output.
This PR just transports them to the Python side in the Close Page phase.
They will be logged only if the close page is called explicitly.
Working on this by changing our auto closing and listener API to 3 so that we can impact test execution result and test model in _end_suite and _end_test.