### PR TITLE
fixed typo in click documentation

### DIFF
--- a/Browser/keywords/interaction.py
+++ b/Browser/keywords/interaction.py
@@ -275,7 +275,7 @@ class Interaction(LibraryComponent):
 
         ``button`` Defaults to ``left`` if invalid.
 
-        ``click_count`` Defaults to 1.
+        ``clickCount`` Defaults to 1.
 
         ``delay`` Time to wait between mouse-down and mouse-up.
         Defaults to 0.


### PR DESCRIPTION
Typo at the Click keyword. In arguments it says clickCount in the documentation click_count, clickCount is accepted in the keyword