### PR TITLE
Close playwright process on exit

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -712,12 +712,6 @@ class Browser(DynamicCore):
     def browser_output(self) -> Path:
         return Path(self.outputdir, "browser")
 
-    def _close(self):
-        try:
-            self.playwright.close()
-        except ConnectionError as e:
-            logger.trace(f"Browser library closing problem: {e}")
-
     def _start_suite(self, suite, result):
         if not self._suite_cleanup_done and self.browser_output.is_dir():
             self._suite_cleanup_done = True

--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import atexit
 import contextlib
 import os
 import time
@@ -47,6 +48,7 @@ class Playwright(LibraryComponent):
     @cached_property
     def _playwright_process(self) -> Optional[Popen]:
         process = self.start_playwright()
+        atexit.register(self.close)
         self.wait_until_server_up()
         return process
 

--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -151,11 +151,17 @@ class Playwright(LibraryComponent):
 
     def close(self):
         logger.debug("Closing all open browsers, contexts and pages in Playwright")
-        with self.grpc_channel() as stub:
-            response = stub.CloseAllBrowsers(Request().Empty())
-            logger.info(response.log)
-        self._channel.close()
-        playwright_process = self._playwright_process
+
+        try:
+            with self.grpc_channel() as stub:
+                response = stub.CloseAllBrowsers(Request().Empty())
+                logger.info(response.log)
+            self._channel.close()
+        except Exception as exc:
+            logger.debug(f"Failed to close browsers: {exc}")
+
+        # Access (possibly) cached property without actually invoking it
+        playwright_process = self.__dict__.get("_playwright_process")
         if playwright_process:
             logger.debug("Closing Playwright process")
             playwright_process.kill()

--- a/tasks.py
+++ b/tasks.py
@@ -5,6 +5,7 @@ import zipfile
 from pathlib import Path, PurePath
 import platform
 import re
+import traceback
 import shutil
 
 from invoke import task, Exit
@@ -20,6 +21,7 @@ try:
     import bs4
     from Browser.utils import find_free_port
 except ModuleNotFoundError:
+    traceback.print_exc()
     print('Assuming that this is for "inv deps" command and ignoring error.')
 
 ROOT_DIR = Path(os.path.dirname(__file__))

--- a/tasks.py
+++ b/tasks.py
@@ -8,10 +8,10 @@ import re
 import shutil
 
 from invoke import task, Exit
-from robot import rebot_cli
-from robot import __version__ as robot_version
 
 try:
+    from robot import rebot_cli
+    from robot import __version__ as robot_version
     from pabot import pabot
     import pytest
     from rellu import ReleaseNotesGenerator, Version


### PR DESCRIPTION
This PR fixes #1033 

Rundown of changes:
- Register Playwright `close` method to run on Python process exit
- Change `close` logic to always kill its subprocess, even if grpc throws an exception
- Change cached property access to not accidentally spawn a server on close
- Remove now superfluous listener method to not call `close` twice per process (which is ok but pointless)

Wasn't exactly sure where to put the atexit call, but in general it should be as late as possible because the registered methods are executed in LIFO order and we want our low-level stuff to still be available, but it also should always run even if something unexpected throws.
