### PR TITLE
Set PLAYWRIGHT_BROWSERS_PATH to "0" only when not explicitly set by the user

### DIFF
--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -93,7 +93,7 @@ class Playwright(LibraryComponent):
             os.environ["DEBUG"] = "pw:api"
         logger.info(f"Starting Browser process {playwright_script} using port {port}")
         self.port = port
-        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = "0"
+        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = os.getenv("PLAYWRIGHT_BROWSERS_PATH") or "0"
         return Popen(
             ["node", str(playwright_script), port],
             shell=False,


### PR DESCRIPTION
Fixes #992

Set `PLAYWRIGHT_BROWSERS_PATH` to `"0"` only when not explicitly set by the user