### PR TITLE
Setting browser path by PLAYWRIGHT_BROWSERS_PATH not working anymore

### DIFF
--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -93,7 +93,7 @@ class Playwright(LibraryComponent):
             os.environ["DEBUG"] = "pw:api"
         logger.info(f"Starting Browser process {playwright_script} using port {port}")
         self.port = port
-        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = "0"
+        os.environ["PLAYWRIGHT_BROWSERS_PATH"] = os.getenv("PLAYWRIGHT_BROWSERS_PATH") or "0"
         return Popen(
             ["node", str(playwright_script), port],
             shell=False,

--- a/README.md
+++ b/README.md
@@ -27,10 +27,34 @@ Only Python 3.7 or newer is supported.
 
 Please note that by default Chromium, Firefox and WebKit browser are installed, even those would be already
 installed in the system. The installation size depends on the operating system, but usually is +700Mb.
-It is possible to skip browser binaries installation with `rfbrowser init --skip-browsers` command, but then user
-is responsible for browser binary installation.
+It is possible to skip browser binaries installation if you wish to have a common browser directory shared by several development environments:
+1. Install dependencies without downloading browser binaries
+```
+rfbrowser init --skip-browsers
+```
 
-Or use the [docker images](https://github.com/MarketSquare/robotframework-browser/packages). Documented at [atest/docker/README.md](https://github.com/MarketSquare/robotframework-browser/blob/main/atest/docker/README.md).
+2. Set environment variable `PLAYWRIGHT_BROWSERS_PATH` according to your shell
+```shell
+# Linux/macOS
+export PLAYWRIGHT_BROWSERS_PATH=/home/user/desired_pw_browsers_path
+```
+```Powershell
+# Windows with cmd.exe
+set PLAYWRIGHT_BROWSERS_PATH=%USERPROFILE%\desired_pw_browsers_path
+
+# Windows with PowerShell
+$env:PLAYWRIGHT_BROWSERS_PATH=$env:USERPROFILE\desired_pw_browsers_path
+```
+3. Install all or specific browsers
+```shell
+npx -g playwright install
+npx -g playwright install firefox
+```
+Run `npx -g playwright install -h` for a guide on supported browser targets. More information for managing browser binaries at [Playwright Docs](https://playwright.dev/docs/browsers).
+
+## Docker install
+
+Use the [docker images](https://github.com/MarketSquare/robotframework-browser/packages). Documented at [atest/docker/README.md](https://github.com/MarketSquare/robotframework-browser/blob/main/atest/docker/README.md).
 
 ## Update instructions
 


### PR DESCRIPTION
A redo of #1229 because the branch renamed.

Fixes #992
Set `PLAYWRIGHT_BROWSERS_PATH` to `"0"` only when not explicitly set by the user

I don't have an idea yet on how to test this.