### PR TITLE
Fix frame piercing selectors

### DIFF
--- a/atest/test/04_frames/deep_frames.robot
+++ b/atest/test/04_frames/deep_frames.robot
@@ -13,7 +13,12 @@ Second level
 
 Third level
     ${style} =    Get Style    id=b >>> id=c >>> id=cc    width
+    Should Be Equal    ${style}    auto
     Get Text    id=b >>> id=c >>> id=cc    ==    This is c
+
+Third level executing JS
+    Execute Javascript    (element) => element.textContent = "foo"    id=b >>> id=c >>> id=cc
+    Get Text    id=b >>> id=c >>> id=cc    ==    foo
 
 Third level from second
     New Page    ${DEEP_FRAMES_2ND_URL}

--- a/node/playwright-wrapper/playwirght-invoke.ts
+++ b/node/playwright-wrapper/playwirght-invoke.ts
@@ -119,9 +119,13 @@ export async function determineElement<T>(state: PlaywrightState, selector: stri
     const page = state.getActivePage();
     exists(page, `Tried to do playwright action, but no open page.`);
     if (isFramePiercingSelector(selector)) {
-        const { frameSelector, elementSelector } = splitFrameAndElementSelector(selector);
-        const frame = await findFrame(page, frameSelector);
-        return await frame.$(elementSelector);
+        let selectors = splitFrameAndElementSelector(selector);
+        let frame = await findFrame(page, selectors.frameSelector);
+        while (isFramePiercingSelector(selectors.elementSelector)) {
+            selectors = splitFrameAndElementSelector(selectors.elementSelector);
+            frame = await findFrame(frame, selectors.frameSelector);
+        }
+        return await frame.$(selectors.elementSelector);
     } else if (isElementHandleSelector(selector)) {
         const { elementHandleId, subSelector } = splitElementHandleAndElementSelector(selector);
         const elem = state.getElement(elementHandleId);

--- a/node/playwright-wrapper/playwirght-invoke.ts
+++ b/node/playwright-wrapper/playwirght-invoke.ts
@@ -115,7 +115,7 @@ async function determineContextAndSelector<T>(
     }
 }
 
-export async function determineElement<T>(state: PlaywrightState, selector: string): Promise<ElementHandle | null> {
+export async function determineElement(state: PlaywrightState, selector: string): Promise<ElementHandle | null> {
     const page = state.getActivePage();
     exists(page, `Tried to do playwright action, but no open page.`);
     if (isFramePiercingSelector(selector)) {


### PR DESCRIPTION
determineElement was not doing frame piercing correctly.
This is used in:
Take Screenshot,
Execute Javascript,
Wait For Function,
Get Bounding Box