### PR TITLE
Add proper test setup and teardown to use clean browsers in 06_Examples/open_in_another_tab.robot

### DIFF
--- a/atest/test/06_Examples/open_in_another_tab.robot
+++ b/atest/test/06_Examples/open_in_another_tab.robot
@@ -1,6 +1,9 @@
 *** Settings ***
-Library     OperatingSystem
-Resource    imports.resource
+Library             OperatingSystem
+Resource            imports.resource
+
+Test Setup          Open Browser To No Page
+Test Teardown       Close Browser
 
 *** Test Cases ***
 Open PDF in another tab and download it
@@ -38,6 +41,9 @@ Download with no acceptDownloads fails
     Run keyword and expect error
     ...    Error: Context acceptDownloads is false
     ...    Download    ${WELCOME_URL}
+    Close Browser
+    New Browser
+    [Teardown]    NONE
 
 Open html in another tab
     New Page    ${WELCOME_URL}


### PR DESCRIPTION
If this works, single test failures in `Test.06 Examples.Open In Another Tab` should actually only fail a single test, and not 3 tests when the failures happen.