### PR TITLE
update dead link

### DIFF
--- a/Browser/keywords/device_descriptors.py
+++ b/Browser/keywords/device_descriptors.py
@@ -39,7 +39,7 @@ class Devices(LibraryComponent):
         """Get a single device descriptor with name exactly matching name.
 
         ``name`` Given name of the requested device. See Playwright's
-        [https://github.com/Microsoft/playwright/blob/master/src/server/deviceDescriptors.ts | deviceDescriptors.ts]
+        [https://github.com/microsoft/playwright/blob/master/packages/playwright-core/src/server/deviceDescriptorsSource.json|deviceDescriptorsSource.json]
         for a formatted list.
 
         Allows a concise syntax to set website testing values to exact matches of specific


### PR DESCRIPTION
Link to playwright list of devices was dead, I've replaced it with the correct one (I already replaced in in a previous PR, but the links was appearing twice, here I'm updating the second dead link)