### PR TITLE
JS side keyword docs

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -755,11 +755,11 @@ class Browser(DynamicCore):
             response = stub.InitializeExtension(
                 Request().FilePath(path=os.path.abspath(jsextension))
             )
-            for name in response.keywords:
-                setattr(component, name, self._jskeyword_call(name))
+            for name, doc in zip(response.keywords, response.keywordDocumentations):
+                setattr(component, name, self._jskeyword_call(name, doc))
         return component
 
-    def _jskeyword_call(self, name: str):
+    def _jskeyword_call(self, name: str, doc: str):
         @keyword
         def func(*args):
             with self.playwright.grpc_channel() as stub:
@@ -771,6 +771,8 @@ class Browser(DynamicCore):
                 if response.json == "":
                     return
                 return json.loads(response.json)
+
+        func.__doc__ = doc
 
         return func
 

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -47,7 +47,7 @@ from ..utils import (
 class PlaywrightState(LibraryComponent):
     """Keywords to manage Playwright side Browsers, Contexts and Pages."""
 
-    """ Helpers for Switch_ and Close_ keywords """
+    # Helpers for Switch_ and Close_ keywords
 
     def _correct_browser(self, browser: str):
         if browser == "ALL":

--- a/node/playwright-wrapper/playwright-state.ts
+++ b/node/playwright-wrapper/playwright-state.ts
@@ -48,14 +48,15 @@ export async function initializeExtension(
     request: Request.FilePath,
     state: PlaywrightState,
 ): Promise<Response.Keywords> {
-    const extension: unknown = eval('require')(request.getPath());
+    const extension: Record<string, unknown> = eval('require')(request.getPath());
     state.extension = extension;
-    // @ts-ignore
     return keywordsResponse(
         Object.keys(extension),
-        Object.values(extension).map(
-            (v: {rfdoc?: string}) => v.rfdoc || 'TODO: Add rfdoc string to exposed function to create documentation',
-        ),
+        Object.values(extension).map((v) => {
+            if (!v) return '';
+            const typedV = v as { rfdoc?: string };
+            return typedV.rfdoc ?? 'TODO: Add rfdoc string to exposed function to create documentation';
+        }),
         'ok',
     );
 }

--- a/node/playwright-wrapper/playwright-state.ts
+++ b/node/playwright-wrapper/playwright-state.ts
@@ -54,7 +54,7 @@ export async function initializeExtension(
     return keywordsResponse(
         Object.keys(extension),
         Object.values(extension).map(
-            (v) => v.rfdoc || 'TODO: Add rfdoc string to exposed function to create documentation',
+            (v: {rfdoc?: string}) => v.rfdoc || 'TODO: Add rfdoc string to exposed function to create documentation',
         ),
         'ok',
     );

--- a/node/playwright-wrapper/playwright-state.ts
+++ b/node/playwright-wrapper/playwright-state.ts
@@ -51,7 +51,13 @@ export async function initializeExtension(
     const extension: unknown = eval('require')(request.getPath());
     state.extension = extension;
     // @ts-ignore
-    return keywordsResponse(Object.keys(extension), 'ok');
+    return keywordsResponse(
+        Object.keys(extension),
+        Object.values(extension).map(
+            (v) => v.rfdoc || 'TODO: Add rfdoc string to exposed function to create documentation',
+        ),
+        'ok',
+    );
 }
 
 export async function extensionKeywordCall(

--- a/node/playwright-wrapper/response-util.ts
+++ b/node/playwright-wrapper/response-util.ts
@@ -89,9 +89,10 @@ export function errorResponse(e: unknown) {
     return { code: errorCode, message: errorMessage };
 }
 
-export function keywordsResponse(keywords: string[], logMessage: string) {
+export function keywordsResponse(keywords: string[], keywordDocs: string[], logMessage: string) {
     const response = new Response.Keywords();
     response.setKeywordsList(keywords);
+    response.setKeyworddocumentationsList(keywordDocs);
     response.setLog(logMessage);
     return response;
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "build-test-app": "webpack --config node/webpack.testapp.config.js",
     "watch-test-app": "webpack --config node/webpack.testapp.config.js --watch",
     "build": "node ./node/build.wrapper.js",
-    "lint": "eslint \"node/**/*.{ts,tsx}\" --quiet --fix",
+    "lint": "tsc --project node/tsconfig.json --noEmit && eslint \"node/**/*.{ts,tsx}\" --quiet --fix",
     "grpc_tools_node_protoc": "grpc_tools_node_protoc"
   }
 }

--- a/protobuf/playwright.proto
+++ b/protobuf/playwright.proto
@@ -240,6 +240,7 @@ message Response {
   message Keywords {
     string log = 1;
     repeated string keywords = 2;
+    repeated string keywordDocumentations = 3;
   }
 
   message Bool {


### PR DESCRIPTION
A take on the documentation of JS side extension keywords.
`python -m robot.libdoc Browser::jsextension=tmp/my.js show Myfunc`

And showing:
```
Myfunc
------
Arguments:  [*args]

This is a function.
```

With tmp/my.js
```JavaScript
function myfunc() {
  return 'hello';
}

myfunc.rfdoc = `
  This is a function.
`;

function otherfunc() {
  return 1;
}

otherfunc.rfdoc = `
  This is another function.
`;

function thirdfunc() {
  return 33;
}

exports.__esModule = true;
exports.myfunc = myfunc;
exports.otherfunc = otherfunc;
exports.thirdfunc = thirdfunc;
```