### PR TITLE
Use Run keyword and expect error for failure screenshot tests instead of StatusChecker

### DIFF
--- a/atest/test/06_Failing/custom_failure_screenshot.robot
+++ b/atest/test/06_Failing/custom_failure_screenshot.robot
@@ -5,9 +5,8 @@ Resource    imports.resource
 
 *** Test Cases ***
 Failing with custom screenshot
-    [Documentation]    FAIL STARTS: TimeoutError
     New Page    ${ERROR_URL}
-    Click    .nonexisting4
+    Run Keyword And Expect Error    STARTS: TimeoutError    Click    .nonexisting4
 
 Check screenshot
     file should exist    ${OUTPUT DIR}/browser/screenshot/custom-fail.png

--- a/atest/test/06_Failing/screenshot_on_failure.robot
+++ b/atest/test/06_Failing/screenshot_on_failure.robot
@@ -5,19 +5,16 @@ Resource    imports.resource
 
 *** Test Cases ***
 Failing with screenshot 1
-    [Documentation]    FAIL STARTS: TimeoutError
     New Page    ${ERROR_URL}
-    Click    .nonexisting
+    Run Keyword And Expect Error    STARTS: TimeoutError    Click    .nonexisting
 
 Failing with screenshot 2
-    [Documentation]    FAIL STARTS: TimeoutError
     New Page    ${ERROR_URL}
-    Click    .nonexisting2
+    Run Keyword And Expect Error    STARTS: TimeoutError    Click    .nonexisting2
 
 Failing with screenshot 3
-    [Documentation]    FAIL STARTS: TimeoutError
     New Page    ${ERROR_URL}
-    Click    .nonexisting3
+    Run Keyword And Expect Error    STARTS: TimeoutError    Click    .nonexisting3
 
 Check screenshots
     file should exist    ${OUTPUT DIR}/browser/screenshot/fail-screenshot-1.png


### PR DESCRIPTION
Should let STDOUT / CI logs be a little less misleading, by avoiding having FAIL's there