### PR TITLE
Improve error in case of invalid type SelectAttribute is given to select_options_by

### DIFF
--- a/Browser/keywords/interaction.py
+++ b/Browser/keywords/interaction.py
@@ -630,6 +630,11 @@ class Interaction(LibraryComponent):
             matchers = json.dumps([{"label": s} for s in values])
         elif attribute is SelectAttribute.index:
             matchers = json.dumps([{"index": int(s)} for s in values])
+        else:
+            raise TypeError(
+                'Invalid type for `attribute`. Please specify SelectAttribute["value"], "label" or "index"'
+            )
+
         with self.playwright.grpc_channel() as stub:
             response = stub.SelectOption(
                 Request().SelectElementSelector(


### PR DESCRIPTION
With this code
```
from Browser import Browser

browser = Browser()
browser.new_page("https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select")
browser.select_options_by("css=iframe.interactive >>> css=#pet-select", "label", "Cat")
```
A type error happens, because the "label" argument should be `SelectAttribute["label"]` instead.


The PR improved this hard-to-read error: 
```
Traceback (most recent call last):
  File "/Users/kerkko/Code/robotframework-browser/Browser/playwright.py", line 149, in grpc_channel
    yield playwright_pb2_grpc.PlaywrightStub(self._channel)
  File "/Users/kerkko/Code/robotframework-browser/Browser/keywords/interaction.py", line 634, in select_options_by
    response = stub.SelectOption(
  File "/Users/kerkko/Code/robotframework-browser/.venv/lib/python3.9/site-packages/grpc/_channel.py", line 946, in __call__
    return _end_unary_response_blocking(state, call, False, None)
  File "/Users/kerkko/Code/robotframework-browser/.venv/lib/python3.9/site-packages/grpc/_channel.py", line 849, in _end_unary_response_blocking
    raise _InactiveRpcError(state)
grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
	status = StatusCode.RESOURCE_EXHAUSTED
	details = "SyntaxError: Unexpected end of JSON input"
	debug_error_string = "{"created":"@1643966355.084348000","description":"Error received from peer ipv6:[::1]:63345","file":"src/core/lib/surface/call.cc","file_line":1075,"grpc_message":"SyntaxError: Unexpected end of JSON input","grpc_status":8}"
>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/kerkko/Code/robotframework-browser/broken-str.py", line 6, in <module>
    browser.select_options_by("css=iframe.interactive >>> css=#pet-select", "label", "Cat")
  File "/Users/kerkko/Code/robotframework-browser/Browser/keywords/interaction.py", line 634, in select_options_by
    response = stub.SelectOption(
  File "/opt/homebrew/Cellar/python@3.9/3.9.10/Frameworks/Python.framework/Versions/3.9/lib/python3.9/contextlib.py", line 137, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/Users/kerkko/Code/robotframework-browser/Browser/playwright.py", line 153, in grpc_channel
    raise AssertionError(error.details())
AssertionError: SyntaxError: Unexpected end of JSON input
```

To this:
```
Traceback (most recent call last):
  File "/Users/kerkko/Code/robotframework-browser/broken-str.py", line 6, in <module>
    browser.select_options_by("css=iframe.interactive >>> css=#pet-select", "label", "Cat")
  File "/Users/kerkko/Code/robotframework-browser/Browser/keywords/interaction.py", line 634, in select_options_by
    raise TypeError(
TypeError: Invalid type for `attribute`. Please specify SelectAttribute["value"], "label" or "index"
```