### PR TITLE
fixed Select Options By #1808

### DIFF
--- a/atest/test/02_Content_Keywords/select_lists.robot
+++ b/atest/test/02_Content_Keywords/select_lists.robot
@@ -21,7 +21,7 @@ Get Select Options
 
 Get Select Options Strict
     Run Keyword And Expect Error
-    ...    *strict mode violation*//select*resolved to 5 elements*
+    ...    *strict mode violation*//select*resolved to 6 elements*
     ...    Get Select Options    //select
     Set Strict Mode    False
     ${options} =    Get Select Options    //select
@@ -81,7 +81,7 @@ Select Options By value
     Lists Should Be Equal    ${selected}    ${selection}
 
 Select Options By index
-    ${selection} =    Create List    0    2
+    ${selection} =    Create List    ${0}    ${2}
     ${selected} =    Select Option And Verify Selection    index    select[name=possible_channels]    @{selection}
     Lists Should Be Equal    ${selected}    ${selection}
 
@@ -98,10 +98,27 @@ Select Options By With Nonmatching Selector
     [Teardown]    Set Browser Timeout    ${PLAYWRIGHT_TIMEOUT}
 
 Select Options By Text When Select Does Not Have Value Attribute
-    Select Options By    id=noValue    text    Option 2
+    ${selection} =    Select Options By    id=noValue    text    Option 2
+    Should Be Equal    Option 2    ${selection}[0]
+
+Select Options By Index When Select Does Not Have Value Attribute
+    ${selection} =    Select Options By    id=noValue    index    1
+    Should Be Equal    ${1}    ${selection}[0]
 
 Select Options By Text When Select Value And Text Are Different
-    Select Options By    id=ValueAndTextDifferent    text    0
+    ${selection} =    Select Options By    id=ValueAndTextDifferent    text    0
+    Should Be Equal    0    ${selection}[0]
+
+Select Options By Value When Select Value And Text Are Different
+    ${selection} =    Select Options By    id=ValueAndTextDifferent    value    2
+    Should Be Equal    2    ${selection}[0]
+
+Select Options By Text When Select Value is Duplicated
+    ${selection} =    Select Options By    id=ValueDupl    text    2nd Option
+    Should Be Equal    2nd Option    ${selection}[0]
+    Get Selected Options    id=ValueDupl    text    ==    2nd Option
+    Get Selected Options    id=ValueDupl    value    ==    object
+    Get Selected Options    id=ValueDupl    index    ==    ${2}
 
 Deselect Options Implicitly
     Select Option And Verify Selection    text    select[name=possible_channels]
@@ -112,7 +129,7 @@ Deselect Options Explicitly
 
 Deselect Options With Strict
     Run Keyword And Expect Error
-    ...    *strict mode violation*//select*resolved to 5 elements*
+    ...    *strict mode violation*//select*resolved to 6 elements*
     ...    Deselect Options    //select
     Set Strict Mode    False
     Deselect Options    //select

--- a/node/dynamic-test-app/static/prefilled_email_form.html
+++ b/node/dynamic-test-app/static/prefilled_email_form.html
@@ -95,6 +95,18 @@
 				</select>
 			</td>
 		</tr>
+        <tr>
+			<td>Select when value is duplicated</td>
+		    <td>
+				<select id="ValueDupl">
+ 					<option value="">DEFAULT OPTION</option>
+ 					<option value="object">1st Option</option>
+ 					<option value="object">2nd Option</option>
+ 					<option value="object">3rd Option</option>
+ 					<option value="object">4th Option</option>
+				</select>
+			</td>
+		</tr>
 		<tr>
 		    <td colspan="2"><input type="submit" name="submit" value="submit"/></td>
 		</tr>

--- a/node/playwright-wrapper/getters.ts
+++ b/node/playwright-wrapper/getters.ts
@@ -41,21 +41,14 @@ export async function getElementCount(request: Request.ElementSelector, state: P
     return intResponse(count, `Found ${count} element(s).`);
 }
 
-export async function getSelectContent(
-    request: Request.ElementSelector,
-    state: PlaywrightState,
-): Promise<Response.Select> {
-    const selector = request.getSelector();
-    const strictMode = request.getStrict();
-    const locator = await findLocator(state, selector, strictMode, undefined, true);
-    await locator.elementHandle();
+export async function getSelections(locator: Locator) {
     const locatorOptions = locator.locator('option');
     const locatorOptionsCount = await locatorOptions.count();
     const response = new Response.Select();
 
     for (let i = 0; i < locatorOptionsCount; i++) {
         const element = await locatorOptions.nth(i).elementHandle();
-        exists(element, `The ${i} option element did not exist.`);
+        exists(element, `The ${i}. option element does not longer exist.`);
         const label = await element.getProperty('label');
         const value = await element.getProperty('value');
         const selected = await element.getProperty('selected');
@@ -66,6 +59,17 @@ export async function getSelectContent(
         response.addEntry(entry);
     }
     return response;
+}
+
+export async function getSelectContent(
+    request: Request.ElementSelector,
+    state: PlaywrightState,
+): Promise<Response.Select> {
+    const selector = request.getSelector();
+    const strictMode = request.getStrict();
+    const locator = await findLocator(state, selector, strictMode, undefined, true);
+    await locator.elementHandle();
+    return await getSelections(locator);
 }
 
 export async function getDomProperty(

--- a/protobuf/playwright.proto
+++ b/protobuf/playwright.proto
@@ -336,7 +336,7 @@ service  Playwright {
   /* Gets the Select element specified by selector and returns the contents */
   rpc GetSelectContent(Request.ElementSelector) returns (Response.Select);
   /* Selects option matching matcher in Select element matching selector */
-  rpc SelectOption(Request.SelectElementSelector) returns (Response.Json);
+  rpc SelectOption(Request.SelectElementSelector) returns (Response.Select);
   /* Deselects options in Select element matching selector */
   rpc DeselectOption(Request.ElementSelector) returns (Response.Empty);
   /* Checks checkbox specified by selector */


### PR DESCRIPTION
`Select Option By` uses now internally the same method to return the selected options as `Get Selected Options`.

Fixes #1808