### PR TITLE
added capability to select ALL when switching

### DIFF
--- a/atest/test/01_Browser_Management/playwright_state.robot
+++ b/atest/test/01_Browser_Management/playwright_state.robot
@@ -275,6 +275,109 @@ When Page Without Context Is Created This Is Logged For User
     New Page
     New Page
 
+Switch Page with ALL Browsers
+    ${browser1} =    New Browser
+    ${context11} =    New Context
+    ${page111} =    New Page
+    ${page112} =    New Page
+    ${context12} =    New Context
+    ${page121} =    New Page
+    ${page122} =    New Page
+    ${browser2} =    New Browser
+    ${context21} =    New Context
+    ${page211} =    New Page
+    ${page212} =    New Page
+    ${context22} =    New Context
+    ${page221} =    New Page
+    ${page222} =    New Page
+
+    ${cat} =    Get Browser Catalog
+    Log    ${cat}
+    ${cur_page} =    Get Page Ids    ACTIVE    ACTIVE    ACTIVE
+    Assert Equal    ${cur_page}[0]    ${page222}[page_id]
+
+    Switch Page    ${page111}    ALL    ALL
+    ${cur_page} =    Get Page Ids    ACTIVE    ACTIVE    ACTIVE
+    Assert Equal    ${cur_page}[0]    ${page111}[page_id]
+
+    Switch Page    ${page212}[page_id]    ALL    ALL
+    ${cur_page} =    Get Page Ids    ACTIVE    ACTIVE    ACTIVE
+    Assert Equal    ${cur_page}[0]    ${page212}[page_id]
+
+    Switch Page    ${page221}    ALL    CURRENT
+    ${cur_page} =    Get Page Ids    ACTIVE    ACTIVE    ACTIVE
+    Assert Equal    ${cur_page}[0]    ${page221}[page_id]
+
+    Switch Page    ${page111}    CURRENT    ALL
+    ${cur_page} =    Get Page Ids    ACTIVE    ACTIVE    ACTIVE
+    Assert Equal    ${cur_page}[0]    ${page111}[page_id]
+
+Switch Context with ALL Browsers
+    ${browser1} =    New Browser
+    ${context11} =    New Context
+    ${page111} =    New Page
+    ${page112} =    New Page
+    ${context12} =    New Context
+    ${page121} =    New Page
+    ${page122} =    New Page
+    ${browser2} =    New Browser
+    ${context21} =    New Context
+    ${page211} =    New Page
+    ${page212} =    New Page
+    ${context22} =    New Context
+    ${page221} =    New Page
+    ${page222} =    New Page
+
+    ${cat} =    Get Browser Catalog
+    Log    ${cat}
+    ${cur_context} =    Get Context Ids    ACTIVE    ACTIVE
+    Assert Equal    ${cur_context}[0]    ${context22}
+
+    Switch Context    ${context12}    ALL
+    ${cur_context} =    Get Context Ids    ACTIVE    ACTIVE
+    Assert Equal    ${cur_context}[0]    ${context12}
+
+    Switch Context    ${context11}    CURRENT
+    ${cur_context} =    Get Context Ids    ACTIVE    ACTIVE
+    Assert Equal    ${cur_context}[0]    ${context11}
+
+Switch Page with ALL Browsers Failing
+    ${browser1} =    New Browser
+    ${context11} =    New Context
+    ${page111} =    New Page
+    ${page112} =    New Page
+    ${context12} =    New Context
+    ${page121} =    New Page
+    ${page122} =    New Page
+    ${browser2} =    New Browser
+    ${context21} =    New Context
+    ${page211} =    New Page
+    ${page212} =    New Page
+    ${context22} =    New Context
+    ${page221} =    New Page
+    ${page222} =    New Page
+
+    ${cat} =    Get Browser Catalog
+    Log    ${cat}
+    ${cur_page} =    Get Page Ids    ACTIVE    ACTIVE    ACTIVE
+    Assert Equal    ${cur_page}[0]    ${page222}[page_id]
+
+    Run Keyword And Expect Error    EQUALS:ValueError: No page with requested id 'page=123' found.
+    ...    Run Keyword And Continue On Failure
+    ...    Switch Page    page=123    ALL    ALL
+
+    Run Keyword And Expect Error
+    ...    EQUALS:Error: No page for id ${page211}[page_id]. Open pages: { id: ${page221}[page_id], url: about:blank },{ id: ${page222}[page_id], url: about:blank }
+    ...    Run Keyword And Continue On Failure
+    ...    Switch Page
+    ...    ${page211}
+    ...    CURRENT
+    ...    CURRENT
+
+    Run Keyword And Expect Error    EQUALS:ValueError: Malformed page `id`: 1
+    ...    Run Keyword And Continue On Failure
+    ...    Switch Page    1    ALL    ALL
+
 *** Keywords ***
 Open Browser And Assert Login Page
     [Arguments]    ${local_browser}
@@ -288,3 +391,7 @@ New Page Form
 New Page Login
     New Page    ${LOGIN_URL}
     Get Title    matches    (?i)login
+
+Assert Equal
+    [Arguments]    ${one}    ${two}
+    Run Keyword And Continue On Failure    Should Be Equal    ${one}    ${two}

--- a/atest/test/02_Content_Keywords/cookie.robot
+++ b/atest/test/02_Content_Keywords/cookie.robot
@@ -37,7 +37,7 @@ Add Cookie With Url
 Add Cookie With Domain And Path
     [Tags]    no-windows-support
     ${url} =    Get Url
-    ${parsed_url} =    common.Parse Url    ${url}
+    ${parsed_url} =    Common.Parse Url    ${url}
     Add Cookie    Foo    Bar    domain=${parsed_url.netloc}    path=${parsed_url.path}
     ${cookies} =    Get Cookies
     Check Cookie    ${cookies}    1    Foo    Bar
@@ -45,7 +45,7 @@ Add Cookie With Domain And Path
 
 Add Cookie With URL And Domain Should Fail
     ${url} =    Get Url
-    ${parsed_url} =    common.Parse Url    ${url}
+    ${parsed_url} =    Common.Parse Url    ${url}
     Run Keyword And Expect Error
     ...    Error: browserContext.addCookies: Cookie should have either url or domain
     ...    Add Cookie

--- a/atest/test/02_Content_Keywords/screenshot.robot
+++ b/atest/test/02_Content_Keywords/screenshot.robot
@@ -48,17 +48,17 @@ Screenshotting With Jpeg Extension And Quality
 
 Screenshotting With Jpeg Extension And Quality Borders
     Take Screenshot    fullPage=True    fileType=jpeg    quality=0    timeout=10s
-    ${size_0}=    Get File Size    ${OUTPUT_DIR}/browser/screenshot/robotframework-browser-screenshot-1.jpeg
+    ${size_0} =    Get File Size    ${OUTPUT_DIR}/browser/screenshot/robotframework-browser-screenshot-1.jpeg
     Take Screenshot    fullPage=True    fileType=jpeg    quality=-190    timeout=10s
-    ${size_1}=    Get File Size    ${OUTPUT_DIR}/browser/screenshot/robotframework-browser-screenshot-2.jpeg
+    ${size_1} =    Get File Size    ${OUTPUT_DIR}/browser/screenshot/robotframework-browser-screenshot-2.jpeg
     Should Be Equal    ${size_0}    ${size_1}
     Take Screenshot    fullPage=True    fileType=jpeg    quality=100    timeout=10s
-    ${size_100}=    Get File Size    ${OUTPUT_DIR}/browser/screenshot/robotframework-browser-screenshot-3.jpeg
+    ${size_100} =    Get File Size    ${OUTPUT_DIR}/browser/screenshot/robotframework-browser-screenshot-3.jpeg
     Take Screenshot    fullPage=True    fileType=jpeg    quality=2023    timeout=10s
-    ${size_101}=    Get File Size    ${OUTPUT_DIR}/browser/screenshot/robotframework-browser-screenshot-4.jpeg
+    ${size_101} =    Get File Size    ${OUTPUT_DIR}/browser/screenshot/robotframework-browser-screenshot-4.jpeg
     Should Be Equal    ${size_100}    ${size_101}
     Take Screenshot    fullPage=True    fileType=jpeg    quality=50    timeout=10s
-    ${size_50}=    Get File Size    ${OUTPUT_DIR}/browser/screenshot/robotframework-browser-screenshot-5.jpeg
+    ${size_50} =    Get File Size    ${OUTPUT_DIR}/browser/screenshot/robotframework-browser-screenshot-5.jpeg
     Should Be True    ${size_0} < ${size_50} < ${size_100}
     [Teardown]    Remove Files    ${OUTPUT_DIR}/browser/screenshot/*.jpeg
 
@@ -125,49 +125,61 @@ Screenshot Without Active Page
     ...    Take Screenshot
 
 Screenshot With Cropping jpg
-    ${box} =    Get BoundingBox    input >> nth=1    ALL    then    {"x": value["x"] - 10, "y": value["y"] - 10, "width": value["width"] + 20, "height": value["height"] + 20}
+    ${box} =    Get BoundingBox
+    ...    input >> nth=1
+    ...    ALL
+    ...    then
+    ...    {"x": value["x"] - 10, "y": value["y"] - 10, "width": value["width"] + 20, "height": value["height"] + 20}
     ${path} =    Take Screenshot    fileType=jpeg    crop=${box}
     File Should Exist    ${path}
     Should End With    ${path}    .jpeg
     ${width}    ${height} =    Get Image Size    ${path}
     Should Be Equal As Integers    ${height}    ${box}[height]
     Should Be Equal As Integers    ${width}    ${box}[width]
-    [Teardown]    Remove File     ${path}
+    [Teardown]    Remove File    ${path}
 
 Screenshot With Cropping, Masking, Omitting Background(png)
-    ${box} =    Get BoundingBox    input >> nth=1    ALL    then    {"x": value["x"] - 10, "y": value["y"] - 10, "width": value["width"] + 20, "height": value["height"] + 20}
-    ${path} =    Take Screenshot         crop=${box}    mask=input >> nth=1    omitBackground=True
+    ${box} =    Get BoundingBox
+    ...    input >> nth=1
+    ...    ALL
+    ...    then
+    ...    {"x": value["x"] - 10, "y": value["y"] - 10, "width": value["width"] + 20, "height": value["height"] + 20}
+    ${path} =    Take Screenshot    crop=${box}    mask=input >> nth=1    omitBackground=True
     File Should Exist    ${path}
     Should End With    ${path}    .png
     ${width}    ${height} =    Get Image Size    ${path}
     Should Be Equal As Integers    ${height}    ${box}[height]
     Should Be Equal As Integers    ${width}    ${box}[width]
-    ${color}=    Get Pixel Color    ${path}    1    ${height//2}
+    ${color} =    Get Pixel Color    ${path}    1    ${height//2}
     Should Be Equal    ${color}    ${{(0,0,0,0)}}
-    ${color}=    Get Pixel Color    ${path}     ${width//2}   ${height//2}
+    ${color} =    Get Pixel Color    ${path}    ${width//2}    ${height//2}
     Should Be Equal    ${color}    ${{(255,0,255,255)}}
-    ${color}=    Get Pixel Color    ${path}    ${width//2}    2
+    ${color} =    Get Pixel Color    ${path}    ${width//2}    2
     Should Be Equal    ${color}    ${{(255,255,255,255)}}
-    ${path} =    Take Screenshot    EMBED    fileType=png       crop=${box}    mask=input >> nth=1    omitBackground=True
-    [Teardown]    Remove File     ${path}
+    ${path} =    Take Screenshot
+    ...    EMBED
+    ...    fileType=png
+    ...    crop=${box}
+    ...    mask=input >> nth=1
+    ...    omitBackground=True
+    [Teardown]    Remove File    ${path}
 
 Screenshot With fixed Cropping
-    ${path} =    Take Screenshot       crop={"x": 200, "y": 100, "height": 123, "width": 654}
+    ${path} =    Take Screenshot    crop={"x": 200, "y": 100, "height": 123, "width": 654}
     File Should Exist    ${path}
     ${width}    ${height} =    Get Image Size    ${path}
     Should Be Equal As Integers    ${height}    123
     Should Be Equal As Integers    ${width}    654
-    ${color}=    Get Pixel Color    ${path}     ${width//2}    ${height//2}
+    ${color} =    Get Pixel Color    ${path}    ${width//2}    ${height//2}
     Should Be Equal    ${color}    ${{(255,255,255,255)}}
-    [Teardown]    Remove File     ${path}
-
+    [Teardown]    Remove File    ${path}
 
 Screenshot With Omit Background
-    ${path} =    Take Screenshot       crop={"x": 200, "y": 100, "height": 123, "width": 654}    omitBackground=True
+    ${path} =    Take Screenshot    crop={"x": 200, "y": 100, "height": 123, "width": 654}    omitBackground=True
     File Should Exist    ${path}
     ${width}    ${height} =    Get Image Size    ${path}
     Should Be Equal As Integers    ${height}    123
     Should Be Equal As Integers    ${width}    654
-    ${color}=    Get Pixel Color    ${path}     ${width//2}    ${height//2}
+    ${color} =    Get Pixel Color    ${path}    ${width//2}    ${height//2}
     Should Be Equal    ${color}    ${{(0,0,0,0)}}
-    [Teardown]    Remove File     ${path}
+    [Teardown]    Remove File    ${path}

--- a/tasks.py
+++ b/tasks.py
@@ -590,10 +590,10 @@ def lint_robot(c):
         "NormalizeAssignments:equal_sign_type_variables=space_and_equal_sign",
         "--configure",
         "NormalizeNewLines:section_lines=1",
-        "--transform",
-        "RenameKeywords",
-        "--transform",
-        "RenameTestCases",
+        # "--transform",
+        # "RenameKeywords",
+        # "--transform",
+        # "RenameTestCases",
     ]
     if in_ci:
         command.insert(1, "--check")


### PR DESCRIPTION
It is now possible to use `ALL` for Browsers and Contexts in the `Switch Page` and `Switch Context` Keyword.
Therefore it is not longer needed to store the context id together with the page.