### PR TITLE
Do outputdir/Browser folder cleanup only at suite startup

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -867,10 +867,11 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
         return Path(self.outputdir, "browser")
 
     def _start_suite(self, suite, result):
-        if not self._suite_cleanup_done and self.browser_output.is_dir():
+        if not self._suite_cleanup_done:
             self._suite_cleanup_done = True
-            logger.debug(f"Removing: {self.browser_output}")
-            shutil.rmtree(str(self.browser_output), ignore_errors=True)
+            if self.browser_output.is_dir():
+                logger.debug(f"Removing: {self.browser_output}")
+                shutil.rmtree(str(self.browser_output), ignore_errors=True)
         if self._auto_closing_level != AutoClosingLevel.MANUAL:
             try:
                 self._execution_stack.append(self.get_browser_catalog())

--- a/utest/test_browser_folder_cleanup.py
+++ b/utest/test_browser_folder_cleanup.py
@@ -1,0 +1,35 @@
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, PropertyMock
+
+import pytest
+
+
+@pytest.fixture()
+def browser():
+    import Browser
+    return Browser.Browser()
+
+
+def test_cleanup_browser_folder_no_folder(browser):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        browser_folder = Path(tmp_dir) / "browser"
+        assert not browser_folder.is_dir()
+        browser_folder.mkdir()
+        with patch("Browser.Browser.outputdir", new_callable=PropertyMock) as mock_property:
+            mock_property.return_value = tmp_dir
+            browser._start_suite(None, None)
+            assert not browser_folder.is_dir()
+
+
+def test_cleanup_browser_folder_folder(browser):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        browser_folder = Path(tmp_dir) / "browser"
+        assert not browser_folder.is_dir()
+        with patch("Browser.Browser.outputdir", new_callable=PropertyMock) as mock_property:
+            mock_property.return_value = tmp_dir
+            browser._start_suite(None, None)
+            assert not browser_folder.is_dir()
+            browser_folder.mkdir()
+            browser._start_suite(None, None)
+            assert browser_folder.is_dir()


### PR DESCRIPTION
Fixes #1889