### PR TITLE
Clean only subfolder from ouptut/browser folder

### DIFF
--- a/Browser/base/librarycomponent.py
+++ b/Browser/base/librarycomponent.py
@@ -79,19 +79,19 @@ class LibraryComponent:
 
     @property
     def screenshots_output(self):
-        return self.browser_output / "screenshot"
+        return self.library.screenshots_output
 
     @property
     def video_output(self):
-        return self.browser_output / "video"
+        return self.library.video_output
 
     @property
     def traces_output(self):
-        return self.browser_output / "traces"
+        return self.library.traces_output
 
     @property
     def state_file(self):
-        return self.browser_output / "state"
+        return self.library.state_file
 
     def get_timeout(self, timeout: Union[timedelta, None]) -> float:
         return self.library.get_timeout(timeout)

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -874,12 +874,37 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
     def browser_output(self) -> Path:
         return Path(self.outputdir, "browser")
 
+    @property
+    def screenshots_output(self):
+        return self.browser_output / "screenshot"
+
+    @property
+    def video_output(self):
+        return self.browser_output / "video"
+
+    @property
+    def traces_output(self):
+        return self.browser_output / "traces"
+
+    @property
+    def state_file(self):
+        return self.browser_output / "state"
+
     def _start_suite(self, suite, result):
         if not self._suite_cleanup_done:
             self._suite_cleanup_done = True
-            if self.browser_output.is_dir():
-                logger.debug(f"Removing: {self.browser_output}")
-                shutil.rmtree(str(self.browser_output), ignore_errors=True)
+            if self.screenshots_output.is_dir():
+                logger.debug(f"Removing: {self.screenshots_output}")
+                shutil.rmtree(str(self.screenshots_output), ignore_errors=True)
+            if self.video_output.is_dir():
+                logger.debug(f"Removing: {self.video_output}")
+                shutil.rmtree(str(self.video_output), ignore_errors=True)
+            if self.traces_output.is_dir():
+                logger.debug(f"Removing: {self.traces_output}")
+                shutil.rmtree(str(self.traces_output), ignore_errors=True)
+            if self.state_file.is_dir():
+                logger.debug(f"Removing: {self.state_file}")
+                shutil.rmtree(str(self.state_file), ignore_errors=True)
         if self._auto_closing_level != AutoClosingLevel.MANUAL:
             try:
                 self._execution_stack.append(self.get_browser_catalog())

--- a/atest/test/07_Failing/screenshot_on_failure.robot
+++ b/atest/test/07_Failing/screenshot_on_failure.robot
@@ -5,6 +5,8 @@ Resource        imports.resource
 
 Force Tags      slow
 
+Suite Setup    Check Screenshots Before
+
 *** Test Cases ***
 Failing With Screenshot 1
     New Page    ${ERROR_URL}
@@ -23,3 +25,10 @@ Check Screenshots
     File Should Exist    ${OUTPUT DIR}/browser/screenshot/fail-screenshot-2.png
     File Should Exist    ${OUTPUT DIR}/browser/screenshot/fail-screenshot-3.png
     File Should Not Exist    ${OUTPUT DIR}/browser/screenshot/fail-screenshot-4.png
+
+*** Keywords ***
+Check Screenshots Before
+    Remove File    ${OUTPUT DIR}/browser/screenshot/fail-screenshot-1.png
+    Remove File    ${OUTPUT DIR}/browser/screenshot/fail-screenshot-2.png
+    Remove File    ${OUTPUT DIR}/browser/screenshot/fail-screenshot-3.png
+    Remove File    ${OUTPUT DIR}/browser/screenshot/fail-screenshot-4.png

--- a/tasks.py
+++ b/tasks.py
@@ -102,7 +102,7 @@ def deps(c):
 
     if _sources_changed([ROOT_DIR / "./package-lock.json"], npm_deps_timestamp_file):
         arch = " --target_arch=x64" if platform.processor() == "arm" else ""
-        c.run(f"npm install{arch}", env={"PLAYWRIGHT_BROWSERS_PATH": "0"})
+        c.run(f"npm install{arch} --parseable true --progress false", env={"PLAYWRIGHT_BROWSERS_PATH": "0"})
         npm_deps_timestamp_file.touch()
     else:
         print("no changes in package-lock.json, skipping npm install")

--- a/utest/test_browser_folder_cleanup.py
+++ b/utest/test_browser_folder_cleanup.py
@@ -14,14 +14,30 @@ def browser():
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Cleanup does not work in Windows")
 def test_cleanup_browser_folder_no_folder(browser):
+    browser._suite_cleanup_done = False
     with tempfile.TemporaryDirectory() as tmp_dir:
         browser_folder = Path(tmp_dir) / "browser"
         assert not browser_folder.is_dir()
         browser_folder.mkdir()
+        screenshot = browser_folder / "screenshot"
+        screenshot.mkdir()
+        video = browser_folder / "video"
+        video.mkdir()
+        traces = browser_folder / "traces"
+        traces.mkdir()
+        state = browser_folder / "state"
+        state.mkdir()
+        foobar = browser_folder / "foobar"
+        foobar.mkdir()
         with patch("Browser.Browser.outputdir", new_callable=PropertyMock) as mock_property:
             mock_property.return_value = tmp_dir
             browser._start_suite(None, None)
-            assert not browser_folder.is_dir()
+            assert browser_folder.is_dir()
+            assert not screenshot.is_dir()
+            assert not video.is_dir()
+            assert not traces.is_dir()
+            assert not state.is_dir()
+            assert foobar.is_dir()
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="Cleanup does not work in Windows")


### PR DESCRIPTION
Cleans only subfolder created by the Browser library. Fixes #2134