### PR TITLE
Update documentation for "Press Keys" keyword.

### DIFF
--- a/Browser/keywords/interaction.py
+++ b/Browser/keywords/interaction.py
@@ -285,7 +285,7 @@ class Interaction(LibraryComponent):
 
         See playwright's documentation for a more comprehensive list of
         supported input keys.
-        [https://playwright.dev/docs/api/class-page#pagepressselector-key-options | Playwright docs for press.]
+        [https://playwright.dev/docs/api/class-page#page-press | Playwright docs for press.]
 
         Example:
         | # Keyword         Selector                    *Keys


### PR DESCRIPTION
Updated the link to Playwright documentation for "press" that was linked under "Press Keys" keyword. I accidentally pull requested my own fork so that is why this is two commits. First time contributor. Hope that doesn't mess anything up.