### PR TITLE
keyword call banner and secret handling

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -73,6 +73,7 @@ KW_CALL_CONTENT_TEMPLATE = """body::before {{
     white-space: pre;
     bottom: 5px;
     left: 5px;
+    {additional_styles}
 }}"""
 
 KW_CALL_BANNER_FUNCTION = """(content) => {
@@ -707,43 +708,16 @@ class Browser(DynamicCore):
     ):
         """Browser library can be taken into use with optional arguments:
 
-        - ``timeout`` <str>
-          Timeout for keywords that operate on elements. The keywords will wait
-          for this time for the element to appear into the page. Defaults to "10s" => 10 seconds.
-        - ``enable_playwright_debug`` <bool>
-          Enable low level debug information from the playwright tool. Mainly
-          Useful for the library developers and for debugging purposes.
-        - ``auto_closing_level`` < ``TEST`` | ``SUITE`` | ``MANUAL`` >
-          Configure context and page automatic closing. Default is ``TEST``,
-          for more details, see `AutoClosingLevel`
-        - ``retry_assertions_for`` <str>
-          Timeout for retrying assertions on keywords before failing the keywords.
-          This timeout starts counting from the first failure.
-          Global ``timeout`` will still be in effect.
-          This allows stopping execution faster to assertion failure when element is found fast.
-        - ``run_on_failure`` <str>
-          Sets the keyword to execute in case of a failing Browser keyword.
-          It can be the name of any keyword. If the keyword has arguments those must be separated with
-          two spaces for example ``My keyword \\ arg1 \\ arg2``.
-          If no extra action should be done after a failure, set it to ``None`` or any other robot falsy value.
-          Run on failure is not applied when library methods are executed directly from Python.
-        - ``external_browser_executable`` <Dict <SupportedBrowsers, Path>>
-          Dict mapping name of browser to path of executable of a browser.
-          Will make opening new browsers of the given type use the set executablePath.
-          Currently only configuring of `chromium` to a separate executable (chrome,
-          chromium and Edge executables all work with recent versions) works.
-        - ``jsextension`` <str>
-          Path to Javascript module exposed as extra keywords. The module must be in CommonJS.
-        - ``enable_presenter_mode`` <bool | dict>
-          Automatic highlights to interacted components, slowMo and a small pause at the end. Can be enabled
-          by giving True or can be customized by giving a dictionary: `{"duration": "2 seconds", "width": "2px",
-          "style": "dotted", "color": "blue"}` Where `duration` is time format in Robot Framework format, defaults to
-          2 seconds. `width` is width of the marker in pixels, defaults the `2px`. `style` is the style of border,
-          defaults to `dotted`. `color` is the color of the marker, defaults to `blue`.
-        - ``strict`` <bool>
-          If keyword selector points multiple elements and keywords should interact with one element,
-          keyword will fail if ``strict`` mode is true. Strict mode can be changed individually in keywords
-          or by ```et Strict Mode`` keyword.
+        | ``timeout`` | <str>  Timeout for keywords that operate on elements. The keywords will wait for this time for the element to appear into the page. Defaults to "10s" => 10 seconds. |
+        | ``enable_playwright_debug`` | <bool> Enable low level debug information from the playwright tool. Mainly Useful for the library developers and for debugging purposes. |
+        | ``auto_closing_level`` | < ``TEST`` or ``SUITE`` or ``MANUAL`` > Configure context and page automatic closing. Default is ``TEST``, for more details, see `AutoClosingLevel` |
+        | ``retry_assertions_for`` | <str> Timeout for retrying assertions on keywords before failing the keywords. This timeout starts counting from the first failure. Global ``timeout`` will still be in effect. This allows stopping execution faster to assertion failure when element is found fast. |
+        | ``run_on_failure`` | <str> Sets the keyword to execute in case of a failing Browser keyword. It can be the name of any keyword. If the keyword has arguments those must be separated with two spaces for example ``My keyword \\ arg1 \\ arg2``. If no extra action should be done after a failure, set it to ``None`` or any other robot falsy value. Run on failure is not applied when library methods are executed directly from Python. |
+        | ``external_browser_executable`` | <Dict <SupportedBrowsers, Path>> Dict mapping name of browser to path of executable of a browser. Will make opening new browsers of the given type use the set executablePath. Currently only configuring of `chromium` to a separate executable (chrome, chromium and Edge executables all work with recent versions) works. |
+        | ``jsextension`` | <str> Path to Javascript module exposed as extra keywords. The module must be in CommonJS. |
+        | ``enable_presenter_mode`` | <bool or dict> Automatic highlights to interacted components, slowMo and a small pause at the end. Can be enabled by giving True or can be customized by giving a dictionary: `{"duration": "2 seconds", "width": "2px", "style": "dotted", "color": "blue"}` Where `duration` is time format in Robot Framework format, defaults to 2 seconds. `width` is width of the marker in pixels, defaults the `2px`. `style` is the style of border, defaults to `dotted`. `color` is the color of the marker, defaults to `blue`. |
+        | ``strict`` | <bool> If keyword selector points multiple elements and keywords should interact with one element, keyword will fail if ``strict`` mode is true. Strict mode can be changed individually in keywords or by ```et Strict Mode`` keyword. |
+        | ``show_keyword_call_banner`` | <bool or None> If set to ``True``, will show a banner with the keyword name and arguments before the keyword is executed at the bottom of the page. If set to ``False``, will not show the banner. If set to None, which is the default, will show the banner only if the presenter mode is enabled. `Get Page Source` and `Take Screenshot` will not show the banner, because that could negatively affect your test cases/tasks. This feature may be super helpful when you are debugging your tests and using tracing from `New Context` or `Video recording` features. |
         """
         self.timeout = self.convert_timeout(timeout)
         self.retry_assertions_for = self.convert_timeout(retry_assertions_for)
@@ -783,6 +757,7 @@ class Browser(DynamicCore):
         self.presenter_mode = enable_presenter_mode
         self.strict_mode = strict
         self.show_keyword_call_banner = show_keyword_call_banner
+        self.keyword_call_banner_add_style: str = ""
         self._keyword_formatters: dict = {}
         self._current_loglevel: Optional[str] = None
         DynamicCore.__init__(self, libraries)
@@ -1030,20 +1005,6 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
             raise e
 
     def _start_keyword(self, name, attrs):
-        """Take screenshot of tests that have failed due to timeout.
-
-        This method is part of the Listener API implemented by the library.
-
-        This can be done with BuiltIn keyword `Run Keyword If Timeout
-        Occurred`, but the problem there is that you have to remember to
-        put it into your Suite/Test Teardown. Since taking screenshot is
-        the most obvious thing to do on failure, let's do it automatically.
-
-        This cannot be implemented as a `end_test` listener method, since at
-        that time, the teardown has already been executed and browser may have
-        been closed already. This implementation will take the screenshot
-        before the teardown begins to execute.
-        """
         if (
             self.show_keyword_call_banner is False
             or (self.show_keyword_call_banner is None and not self.presenter_mode)
@@ -1097,7 +1058,10 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
     def set_keyword_call_banner(self, keyword_call=None):
         if keyword_call:
             keyword_call = keyword_call.replace("'", "\\'")
-            content = KW_CALL_CONTENT_TEMPLATE.format(keyword_call=keyword_call)
+            content = KW_CALL_CONTENT_TEMPLATE.format(
+                keyword_call=keyword_call,
+                additional_styles=self.keyword_call_banner_add_style,
+            )
         else:
             content = "body::before{}"
 

--- a/Browser/keywords/browser_control.py
+++ b/Browser/keywords/browser_control.py
@@ -17,7 +17,7 @@ import os
 from collections.abc import Iterable
 from datetime import timedelta
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from robot.utils import get_link_path  # type: ignore
 
@@ -287,6 +287,37 @@ class Control(LibraryComponent):
         old_retry_assertions_for = self.millisecs_to_timestr(self.retry_assertions_for)
         self.retry_assertions_for = self.convert_timeout(timeout)
         return old_retry_assertions_for
+
+    @keyword(tags=("Setter", "Config"))
+    def show_keyword_banner(
+        self, show: bool = True, style: str = ""
+    ) -> Dict[str, Union[None, bool, str]]:
+        """Controls if the keyword banner is shown on page or not.
+
+        Keyword call banner is a css overlay that shows the currently executed keyword directly on page.
+        This is useful for debugging and for showing the test execution on video recordings.
+        By default, the banner is not shown on page except when running in presenter mode.
+
+        The banner can be controlled by an import setting of Browser library. (see `Importing` section)
+
+        ``show`` If `True` banner is shown on page. If `False` banner is not shown on page. If `None` banner is shown on page only when running in presenter mode.
+
+        ``style`` Additional css styles to be applied to the banner. These styles are css settings and may override the existing ones for the banner.
+
+
+        Example:
+        | Show Keyword Banner     True    top: 5px; bottom: auto; left: 5px; background-color: #00909077; font-size: 9px; color: black;   # Show banner on top left corner with custom styles
+        | Show Keyword Banner     False   # Hide banner
+
+        [https://forum.robotframework.org/t//4716|Comment >>]
+        """
+        original_state = self.library.show_keyword_call_banner
+        original_style = self.library.keyword_call_banner_add_style
+        self.library.show_keyword_call_banner = show
+        self.library.keyword_call_banner_add_style = style
+        if not show:
+            self.library.set_keyword_call_banner()
+        return {"show": original_state, "style": original_style}
 
     @keyword(tags=("Setter", "BrowserControl"))
     def set_viewport_size(self, width: int, height: int):

--- a/Browser/keywords/interaction.py
+++ b/Browser/keywords/interaction.py
@@ -484,6 +484,7 @@ class Interaction(LibraryComponent):
 
         [https://forum.robotframework.org/t//4255|Comment >>]
         """
+        selector = self.presenter_mode(selector, self.strict_mode)
         with self.playwright.grpc_channel() as stub:
             response = stub.Focus(
                 Request().ElementSelector(selector=selector, strict=self.strict_mode)
@@ -622,6 +623,7 @@ class Interaction(LibraryComponent):
 
         [https://forum.robotframework.org/t//4235|Comment >>]
         """
+        selector = self.presenter_mode(selector, self.strict_mode)
         with self.playwright.grpc_channel() as stub:
             response = stub.CheckCheckbox(
                 Request().ElementSelector(
@@ -645,6 +647,7 @@ class Interaction(LibraryComponent):
 
         [https://forum.robotframework.org/t//4340|Comment >>]
         """
+        selector = self.presenter_mode(selector, self.strict_mode)
         with self.playwright.grpc_channel() as stub:
             response = stub.UncheckCheckbox(
                 Request().ElementSelector(
@@ -695,6 +698,7 @@ class Interaction(LibraryComponent):
 
         [https://forum.robotframework.org/t//4322|Comment >>]
         """
+        selector = self.presenter_mode(selector, self.strict_mode)
         matchers = ""
         if not values or len(values) == 1 and not values[0]:
             self.deselect_options(selector)
@@ -731,6 +735,7 @@ class Interaction(LibraryComponent):
 
         [https://forum.robotframework.org/t//4245|Comment >>]
         """
+        selector = self.presenter_mode(selector, self.strict_mode)
         with self.playwright.grpc_channel() as stub:
             response = stub.DeselectOption(
                 Request().ElementSelector(selector=selector, strict=self.strict_mode)
@@ -939,6 +944,7 @@ class Interaction(LibraryComponent):
 
         [https://forum.robotframework.org/t//4247|Comment >>]
         """
+        selector_from = self.presenter_mode(selector_from, self.strict_mode)
         from_bbox = self.library.get_boundingbox(selector_from)
         from_xy = self._center_of_boundingbox(from_bbox)
         to_bbox = self.library.get_boundingbox(selector_to)
@@ -1016,6 +1022,7 @@ class Interaction(LibraryComponent):
 
         [https://forum.robotframework.org/t//4249|Comment >>]
         """
+        selector_from = self.presenter_mode(selector_from, self.strict_mode)
         from_bbox = self.library.get_boundingbox(selector_from)
         from_xy = self._center_of_boundingbox(from_bbox)
         to_x = from_xy["x"] + x

--- a/atest/test/01_Browser_Management/keyword_banner.py
+++ b/atest/test/01_Browser_Management/keyword_banner.py
@@ -1,0 +1,17 @@
+from robot.libraries.BuiltIn import BuiltIn
+from Browser import Browser
+from assertionengine.assertion_engine import verify_assertion, AssertionOperator
+from typing import Optional
+
+def get_computed_banner_style():
+    b: Browser = BuiltIn().get_library_instance("Browser")
+    return b.evaluate_javascript('body', "element => window.getComputedStyle(element,':before')")
+
+def get_real_page_source(operator: AssertionOperator = None, expected: Optional[str] = None):
+    b: Browser = BuiltIn().get_library_instance("Browser")
+    return verify_assertion(b.get_page_source(), operator, expected)
+
+def get_banner_content(operator: AssertionOperator = None, expected: Optional[str] = None):
+    style = get_computed_banner_style()
+    content = BuiltIn().evaluate(style['content']) if style['content'].startswith('"') else style['content']
+    return verify_assertion(content, operator, expected)

--- a/atest/test/01_Browser_Management/keyword_banner.robot
+++ b/atest/test/01_Browser_Management/keyword_banner.robot
@@ -1,0 +1,85 @@
+*** Settings ***
+Documentation       Tests for Show Keyword Banner
+
+Resource            imports.resource
+Library             ${CURDIR}/keyword_banner.py
+
+Suite Setup         Ensure Open Page
+Test Setup          Go To    ${FORM_URL}
+Test Teardown       Show Keyword Banner    None
+
+
+*** Test Cases ***
+Show Keyword Banner
+    [Documentation]    This test case should show the keyword banner
+    ${original_settings}=    Show Keyword Banner    True
+    Should Be True    $original_settings["show"] == None and $original_settings["style"] == ''
+    Get Selected Options    [name="possible_channels"]    text    validate    value == ["Email", "Telephone"]
+    ${style}=    keyword_banner.Get Computed Banner Style
+    Should Be Equal
+    ...    ${style}[content]
+    ...    "Get Selected Options \ \ \ [name=\\"possible_channels\\"] \ \ \ text \ \ \ validate \ \ \ value == [\\"Email\\", \\"Telephone\\"]"
+    Show Keyword Banner    &{original_settings}
+    Get Title
+    ${style}=    keyword_banner.Get Computed Banner Style
+    Should Be Equal    ${style}[content]    none
+
+Keyword Call Banner Content
+    [Documentation]    This test case should show the keyword banner
+    ${original_settings}=    Show Keyword Banner    True
+    Should Be True    $original_settings["show"] == None and $original_settings["style"] == ''
+    Set Viewport Size    width=1200    height=800
+    keyword_banner.Get Banner Content    ==    Set Viewport Size \ \ \ width=1200 \ \ \ height=800
+    Get Title
+    keyword_banner.Get Banner Content    ==    Get Title
+    Get Viewport Size    ALL    validate    value == {'width': 1200, 'height': 800}
+    keyword_banner.Get Banner Content
+    ...    ==
+    ...    Get Viewport Size \ \ \ ALL \ \ \ validate \ \ \ value == {'width': 1200, 'height': 800}
+    Get Attribute
+    ...    xpath=//input[@name="submit"]
+    ...    attribute=name
+    ...    assertion_operator=should be
+    ...    assertion_expected=submit
+    keyword_banner.Get Banner Content
+    ...    ==
+    ...    Get Attribute \ \ \ xpath=//input[@name="submit"] \ \ \ attribute=name \ \ \ assertion_operator=should be \ \ \ assertion_expected=submit
+
+Get Page Source And Take Screenshot Muting
+    ${original_settings}=    Show Keyword Banner    True
+    Get Title
+    keyword_banner.Get Banner Content    ==    Get Title
+    Take Screenshot    ${OUTPUTDIR}/screenshot.png
+    keyword_banner.Get Banner Content    ==    none
+    Get Viewport Size
+    keyword_banner.Get Banner Content    ==    Get Viewport Size
+    Get Page Source    not contains    I'm warning you! If you say "Jehovah" once more...
+    keyword_banner.Get Banner Content    ==    none
+    keyword_banner.Get Real Page Source    not contains    Jehovah
+    Get Title    not contains    Jehovah
+    keyword_banner.Get Real Page Source    contains    Jehovah
+
+Change Banner CSS
+    Set Viewport Size    width=1200    height=800
+    ${original_settings}=    Show Keyword Banner    True
+    Get Title
+    ${style}=    keyword_banner.Get Computed Banner Style
+    Should Be Equal    ${style}[left]    5px
+    Should Be Equal    ${style}[bottom]    5px
+    Show Keyword Banner
+    ...    show=True
+    ...    style=top: 5px; bottom: auto; background-color: red; color: white; font-size: 20px; font-family: monospace; padding: 10px; border: 1px solid black; border-radius: 5px;
+    Get Title
+    ${style}=    keyword_banner.Get Computed Banner Style
+    Should Be Equal    ${style}[top]    5px
+    Should Be Equal    ${style}[left]    5px
+    Should Be Equal    ${style}[backgroundColor]    rgb(255, 0, 0)
+    Should Be Equal    ${style}[color]    rgb(255, 255, 255)
+    Should Be Equal    ${style}[fontSize]    20px
+    Should Be Equal    ${style}[fontFamily]    monospace
+    Should Be Equal    ${style}[paddingLeft]    10px
+    Should Be Equal    ${style}[paddingRight]    10px
+    Should Be Equal    ${style}[paddingTop]    10px
+    Should Be Equal    ${style}[paddingBottom]    10px
+    Should Be Equal    ${style}[borderRadius]    5px
+

--- a/node/playwright-wrapper/evaluation.ts
+++ b/node/playwright-wrapper/evaluation.ts
@@ -194,7 +194,7 @@ export async function recordSelector(
         return myselectors;
     });
     page.exposeFunction('highlightPWSelector', (selector: string) => {
-        highlightAll(selector, 1000, '3px', 'dotted', 'silver', false, state);
+        highlightAll(selector, 1000, '3px', 'dotted', 'blue', false, state);
     });
     const result = await recordSelectorIterator(request.getLabel(), page.mainFrame());
     return jsResponse(result, 'Selector recorded.');

--- a/node/playwright-wrapper/static/selector-finder.js
+++ b/node/playwright-wrapper/static/selector-finder.js
@@ -183,8 +183,11 @@ function cssesc(a, b = {}) {
         return b && b.length % 2 ? a : (b || "") + c
     }), !e && c.wrap ? d + g + d : g
 }
-/* Cool work ends and Browser library work begins */
 
+/* Cool work ends and Browser library work begins */
+const BROWSER_LIBRARY_SELECTOR_CLASS = "browser-library-selector-class";
+const BROWSER_LIBRARY_MONOSPACED_CLASS = "browser-library-monospaced-class";
+const BROWSER_LIBRARY_SYSFONT_CLASS = "browser-library-sysfont-class";
 const BROWSER_LIBRARY_ID = "browser-library-selector-recorder";
 const BROWSER_LIBRARY_HEADER_ID = "browser-library-selector-recorder-header";
 const BROWSER_LIBRARY_TEXT_ID = "browser-library-selector-recorder-target-text";
@@ -193,9 +196,12 @@ const BROWSER_LIBRARY_SELECT_CANCEL_BUTTON_ID = "browser-library-cancel-selector
 const BROWSER_LIBRARY_DESCRIPTION = "browser-library-selector-recorder-description-text";
 const BROWSER_LIBRARY_SELECTION = "browser-library-selection-id";
 const BROWSER_LIBRARY_SELECTIONS = "browser-library-selections-id";
+const BROWSER_LIBRARY_SELECTION_FRAME = "browser-library-selection-frame";
+const BROWSER_LIBRARY_SELECTION_PANEL = "browser-library-selection-panel";
 const BROWSER_LIBRARY_SELECTION_OK_BUTTON = "browser-library-selection-ok-button";
 const BROWSER_LIBRARY_SELECTION_CANCEL_BUTTON = "browser-library-selection-cancel-button";
 const BROWSER_LIBRARY_SELECTION_HIGHLIGHT_BUTTON = "browser-library-selection-highlight-button";
+const BROWSER_LIBRARY_SELECTION_BUTTON_CLASS = "browser-library-selection-button-class";
 
 function htmlToElement(html) {
     var template = document.createElement('template');
@@ -204,65 +210,55 @@ function htmlToElement(html) {
     return template.content.firstChild;
 }
 
-function addElement (label) {
+function addElement(label) {
     const newDiv = htmlToElement(`
-    <div style="display: flex;
-    flex-direction: column;
-    border: 2px solid blue;
-    border-radius: 5px;
-    z-index: 2147483647;
-    position: fixed;
-    top: 16px;
-    left: 16px;
-    background: white;
-    color: black;
-    padding: 8px;" id="${BROWSER_LIBRARY_ID}">
-        <h5 id="${BROWSER_LIBRARY_HEADER_ID}" style="cursor: move; background: rgb(178,227,227)">
-        ${"Selector recorder" + (label && label.length ? " for " + label : "")}
+    <div id="${BROWSER_LIBRARY_ID}" class="${BROWSER_LIBRARY_SELECTOR_CLASS}">
+        <h5 id="${BROWSER_LIBRARY_HEADER_ID}" class="${BROWSER_LIBRARY_SYSFONT_CLASS}">
+        ${"Selector Recorder" + (label && label.length ? " For '" + label + "'" : "")}
         </h5>
-        <span id="${BROWSER_LIBRARY_TEXT_ID}">NOTSET</span>
-        <span id="${BROWSER_LIBRARY_DESCRIPTION}"></span>
-        <span style="max-width: 300px">Move mouse and Hover over an element to record a selector.</span>
+        <span id="${BROWSER_LIBRARY_TEXT_ID}" class="${BROWSER_LIBRARY_MONOSPACED_CLASS}">NOTSET</span>
+        <span id="${BROWSER_LIBRARY_DESCRIPTION}" class="${BROWSER_LIBRARY_MONOSPACED_CLASS}"></span>
+        <span style="max-width: 300px" class="${BROWSER_LIBRARY_SYSFONT_CLASS}">Move mouse and Hover over an element to record a selector.</span>
     </div>
     `)
-  const elem = document.body.appendChild(newDiv);
-  dragElement(elem, document.getElementById(BROWSER_LIBRARY_HEADER_ID));
-  setTimeout(() => elem.focus(), 300);
+    const elem = document.body.appendChild(newDiv);
+    dragElement(elem, document.getElementById(BROWSER_LIBRARY_HEADER_ID));
+    setTimeout(() => elem.focus(), 300);
 }
 
 function dragElement(elmnt, header) {
-  let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
-  header.onmousedown = dragMouseDown;
+    let pos1 = 0, pos2 = 0, pos3 = 0, pos4 = 0;
+    header.onmousedown = dragMouseDown;
 
-  function dragMouseDown(e) {
-    e = e || window.event;
-    e.preventDefault();
-    // get the mouse cursor position at startup:
-    pos3 = e.clientX;
-    pos4 = e.clientY;
-    document.onmouseup = closeDragElement;
-    // call a function whenever the cursor moves:
-    document.onmousemove = elementDrag;
-  }
+    function dragMouseDown(e) {
+        e = e || window.event;
+        e.preventDefault();
+        // get the mouse cursor position at startup:
+        pos3 = e.clientX;
+        pos4 = e.clientY;
+        document.onmouseup = closeDragElement;
+        // call a function whenever the cursor moves:
+        document.onmousemove = elementDrag;
+    }
 
-  function elementDrag(e) {
-    e = e || window.event;
-    e.preventDefault();
-    // calculate the new cursor position:
-    pos1 = pos3 - e.clientX;
-    pos2 = pos4 - e.clientY;
-    pos3 = e.clientX;
-    pos4 = e.clientY;
-    // set the element's new position:
-    elmnt.style.top = (elmnt.offsetTop - pos2) + "px";
-    elmnt.style.left = (elmnt.offsetLeft - pos1) + "px";
-  }
+    function elementDrag(e) {
+        e = e || window.event;
+        e.preventDefault();
+        // calculate the new cursor position:
+        pos1 = pos3 - e.clientX;
+        pos2 = pos4 - e.clientY;
+        pos3 = e.clientX;
+        pos4 = e.clientY;
+        // set the element's new position:
+        elmnt.style.top = (elmnt.offsetTop - pos2) + "px";
+        elmnt.style.left = (elmnt.offsetLeft - pos1) + "px";
+    }
 
-  function closeDragElement() {
-    // stop moving when mouse button is released:
-    document.onmouseup = null;
-    document.onmousemove = null;
-  }
+    function closeDragElement() {
+        // stop moving when mouse button is released:
+        document.onmouseup = null;
+        document.onmousemove = null;
+    }
 }
 
 function elementSelectorFromPointInFrame(x, y) {
@@ -272,37 +268,45 @@ function elementSelectorFromPointInFrame(x, y) {
             return '???';
         }
         if (element.shadowRoot) {
-            const parentSelector = finder(element, {root:parentElement})
+            const parentSelector = finder(element, {root: parentElement})
             const [childSelector, rect] = subelementFromPoint(element.shadowRoot);
             return [childSelector.map(s => parentSelector + " >> " + s), rect];
         }
         const rect = element.getBoundingClientRect();
         const left = parseFloat(window.getComputedStyle(element, null).getPropertyValue('padding-left')) || 0;
-        const top =  parseFloat(window.getComputedStyle(element, null).getPropertyValue('padding-top')) || 0;
+        const top = parseFloat(window.getComputedStyle(element, null).getPropertyValue('padding-top')) || 0;
         const selectors = [];
-        const selector1 = finder(element, {root:parentElement})
+        const selector1 = finder(element, {root: parentElement})
         selectors.push(selector1);
-        const selector2 = finder(element, {root:parentElement,
-            className: (c) => !selector1.includes("."+c),
+        const selector2 = finder(element, {
+            root: parentElement,
+            className: (c) => !selector1.includes("." + c),
         });
         if (!selectors.includes(selector2)) selectors.push(selector2);
         const selector3 = finder(element, {
             root: parentElement,
-            idName: (id) => !selector1.includes('#'+id)
+            idName: (id) => !selector1.includes('#' + id)
         });
         if (!selectors.includes(selector3)) selectors.push(selector3);
         const selector4 = finder(element, {
             root: parentElement,
-            className: (c) => !selector1.includes("."+c),
-            idName: (id) => !selector1.includes('#'+id),
+            className: (c) => !selector1.includes("." + c),
+            idName: (id) => !selector1.includes('#' + id),
         });
         if (!selectors.includes(selector4)) selectors.push(selector4);
-        return [selectors, {top: rect.top, left: rect.left, height: rect.height, width: rect.width, paddingLeft: left, paddingTop: top}];
+        return [selectors, {
+            top: rect.top,
+            left: rect.left,
+            height: rect.height,
+            width: rect.width,
+            paddingLeft: left,
+            paddingTop: top
+        }];
     }
     return subelementFromPoint(document);
 }
 
-window.subframeSelectorRecorderFindSelector = function(myid) {
+window.subframeSelectorRecorderFindSelector = function (myid) {
 
     let currentCssSelector = "NOTSET";
 
@@ -317,7 +321,7 @@ window.subframeSelectorRecorderFindSelector = function(myid) {
     document.addEventListener('mousemove', mouseMoveListener);
 }
 
-window.selectorRecorderFindSelector = function(label) {
+window.selectorRecorderFindSelector = function (label) {
     return new Promise((resolve) => {
         let currentCssSelector = "NOTSET";
         let lastTotalRecord = [];
@@ -342,60 +346,36 @@ window.selectorRecorderFindSelector = function(label) {
                     findingElement = false;
                     const rect = selectors.map(i => i[1]).reduce((acc, cur) => {
                         return {
-                            top: acc.top+cur.top+acc.paddingTop, left: acc.left+cur.left+acc.paddingLeft, width: cur.width, height: cur.height,
-                            paddingLeft: cur.paddingLeft, paddingTop: cur.paddingTop
+                            top: acc.top + cur.top + acc.paddingTop,
+                            left: acc.left + cur.left + acc.paddingLeft,
+                            width: cur.width,
+                            height: cur.height,
+                            paddingLeft: cur.paddingLeft,
+                            paddingTop: cur.paddingTop
                         }
                     }, {
                         top: 0, left: 0, width: 0, height: 0, paddingTop: 0, paddingLeft: 0
                     });
-                    const div = htmlToElement(`<div style="
-position: absolute;
-top: ${rect.top-window.scrollY}px;
-left: ${rect.left-window.scrollX}px;
-width: ${rect.width}px;
-height: ${rect.height}px;
-border: 3px solid green;
-z-index: 2147483646;
-">
-<style>
-#${BROWSER_LIBRARY_SELECT_BUTTON_ID} {
-    background: white;
-    color: black;
-    font-family: system-ui, -apple-system, sans-serif;
-    border: 3px solid green;
-    border-radius: 6px;
-    cursor: pointer;
-    margin: 0.5rem;
-    box-shadow: 2px 2px 5px darkolivegreen;
-}
-#${BROWSER_LIBRARY_SELECT_BUTTON_ID}:hover {
-    background: silver;
-    border-color: greenyellow;
-}
-#${BROWSER_LIBRARY_SELECT_CANCEL_BUTTON_ID} {
-    background: white;
-    border: 3px solid green;
-    border-radius: 6px;
-    cursor: pointer;
-    margin: 0.5rem;
-    box-shadow: 2px 2px 5px darkolivegreen;
-}
-#${BROWSER_LIBRARY_SELECT_CANCEL_BUTTON_ID}:hover {
-    background: silver;
-    border-color: greenyellow;
-}
-</style>
+                    const div = htmlToElement(`<div id="${BROWSER_LIBRARY_SELECTION_FRAME}" style="
+top: ${rect.top - window.scrollY - 2}px;
+left: ${rect.left - window.scrollX - 2}px;
+width: ${rect.width + 4}px;
+height: ${rect.height+ 4}px;
+
+"><div class="found-element animate-flicker" style="
+width: 100%;
+height: 100%;
+
+"></div>
 <div
 style="
 position: relative;
 display: flex;
-flex-wrap: wrap;
-top: ${rect.height}px;
-"
+flex-wrap: wrap;"
 >
-<button id="${BROWSER_LIBRARY_SELECT_BUTTON_ID}"
+<button id="${BROWSER_LIBRARY_SELECT_BUTTON_ID}" class="${BROWSER_LIBRARY_SELECTOR_CLASS}"
 >Select</button>
-<button id="${BROWSER_LIBRARY_SELECT_CANCEL_BUTTON_ID}"
+<button id="${BROWSER_LIBRARY_SELECT_CANCEL_BUTTON_ID}" class="${BROWSER_LIBRARY_SELECTOR_CLASS}"
 >Cancel</button>
 </div>
 </div>`);
@@ -431,36 +411,16 @@ top: ${rect.height}px;
                 const item = lastTotalRecord.map(j => j[i]).join(" >>> ");
                 options.push(item);
             }
-            const oldelement = document.getElementById(BROWSER_LIBRARY_ID);
-            const div = htmlToElement(`<div style="
+            const oldElement = document.getElementById(BROWSER_LIBRARY_ID);
+            const oldPosition = oldElement.getBoundingClientRect();
+            const div = htmlToElement(`<div id="${BROWSER_LIBRARY_SELECTION_PANEL}" class="${BROWSER_LIBRARY_SELECTOR_CLASS}" style="
     display: flex;
     flex-direction: column;
-    border: 2px solid blue;
-    border-radius: 5px;
     z-index: 2147483647;
     position: fixed;
-    top: ${oldelement.style.top};
-    left: ${oldelement.style.left};
-    background: white;
-    padding: 8px;">
+    top: ${oldPosition.top}px;
+    left: ${oldPosition.left}px;">
 <style>
-#${BROWSER_LIBRARY_SELECTION} {
-    background: #d5d5d5;
-    color: blue;
-    padding: 4px;
-}
-#${BROWSER_LIBRARY_SELECTION_OK_BUTTON} {
-    color: black;
-    background: white;
-}
-#${BROWSER_LIBRARY_SELECTION_HIGHLIGHT_BUTTON} {
-    color: black;
-    background: white;
-}
-#${BROWSER_LIBRARY_SELECTION_CANCEL_BUTTON} {
-    color: black;
-    background: white;
-}
 </style>
 <span>Select selector pattern to use:</span>
 <input id="${BROWSER_LIBRARY_SELECTION}"
@@ -470,11 +430,11 @@ top: ${rect.height}px;
 <datalist id="${BROWSER_LIBRARY_SELECTIONS}">
 ${options.map(o => `<option value="${o}"/>`).join("\n")}
 </datalist>
-<button id="${BROWSER_LIBRARY_SELECTION_OK_BUTTON}">Select</button>
-<button id="${BROWSER_LIBRARY_SELECTION_HIGHLIGHT_BUTTON}">Highlight</button>
-<button id="${BROWSER_LIBRARY_SELECTION_CANCEL_BUTTON}">Cancel</button>
+<button id="${BROWSER_LIBRARY_SELECTION_OK_BUTTON}" class="${BROWSER_LIBRARY_SELECTION_BUTTON_CLASS} ${BROWSER_LIBRARY_SELECTOR_CLASS}">Take It</button>
+<button id="${BROWSER_LIBRARY_SELECTION_HIGHLIGHT_BUTTON}" class="${BROWSER_LIBRARY_SELECTION_BUTTON_CLASS} ${BROWSER_LIBRARY_SELECTOR_CLASS}">Highlight</button>
+<button id="${BROWSER_LIBRARY_SELECTION_CANCEL_BUTTON}" class="${BROWSER_LIBRARY_SELECTION_BUTTON_CLASS} ${BROWSER_LIBRARY_SELECTOR_CLASS}">Reselect</button>
 </div>`);
-            oldelement.style.visibility = 'hidden';
+            oldElement.style.visibility = 'hidden';
             document.body.appendChild(div);
             const selection = document.getElementById(BROWSER_LIBRARY_SELECTION)
             document.getElementById(BROWSER_LIBRARY_SELECTION_OK_BUTTON).onclick = () => {
@@ -484,7 +444,7 @@ ${options.map(o => `<option value="${o}"/>`).join("\n")}
                 resolve(selection.value);
             };
             document.getElementById(BROWSER_LIBRARY_SELECTION_CANCEL_BUTTON).onclick = () => {
-                oldelement.style.visibility = 'visible';
+                oldElement.style.visibility = 'visible';
                 focusDiv.remove();
                 div.remove();
                 findingElement = true;
@@ -520,6 +480,163 @@ ${options.map(o => `<option value="${o}"/>`).join("\n")}
         }
 
         document.addEventListener('mousemove', mouseMoveListener);
+        const style = htmlToElement(`<style>
+#${BROWSER_LIBRARY_SELECTION_FRAME}{
+    position: absolute;
+    z-index: 2147483646;
+}
+@keyframes flickerAnimation {
+  0%   { opacity:1; }
+  50%  { opacity:0; }
+  100% { opacity:1; }
+}
+@-o-keyframes flickerAnimation{
+  0%   { opacity:1; }
+  50%  { opacity:0; }
+  100% { opacity:1; }
+}
+@-moz-keyframes flickerAnimation{
+  0%   { opacity:1; }
+  50%  { opacity:0; }
+  100% { opacity:1; }
+}
+@-webkit-keyframes flickerAnimation{
+  0%   { opacity:1; }
+  50%  { opacity:0; }
+  100% { opacity:1; }
+}
+.animate-flicker {
+   -webkit-animation: flickerAnimation 1s infinite;
+   -moz-animation: flickerAnimation 1s infinite;
+   -o-animation: flickerAnimation 1s infinite;
+    animation: flickerAnimation 1s infinite;
+}
+.found-element{
+    border: 2px dashed green;
+    box-shadow:0 0 20px green;
+}
+
+#${BROWSER_LIBRARY_ID} {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid lightblue;
+    border-radius: 15px;
+    z-index: 2147483647;
+    position: fixed;
+    top: 56px;
+    left: 99px;
+    background: rgba(0, 0, 139, 0.5);
+    padding: 12px;
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
+}
+
+#${BROWSER_LIBRARY_HEADER_ID} {
+    cursor: move;
+    background: lightgray;
+    color: darkblue;
+    border-radius: 3px;
+    padding: 0px 5px;
+    margin: 0px;
+    margin-bottom: 10px;
+}
+
+
+.${BROWSER_LIBRARY_SELECTOR_CLASS},
+.${BROWSER_LIBRARY_MONOSPACED_CLASS} {
+    font-family: monospace;
+    font-size: medium;
+    font-weight: normal;
+}
+
+.${BROWSER_LIBRARY_SYSFONT_CLASS},
+button.${BROWSER_LIBRARY_SELECTOR_CLASS} {
+    font-family: system-ui, -apple-system, sans-serif !important;
+}
+
+.${BROWSER_LIBRARY_SELECTOR_CLASS} {
+    color: white;
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
+    box-shadow: 2px 2px 5px darkblue;
+}
+
+#${BROWSER_LIBRARY_SELECT_BUTTON_ID} {
+    background: #00008b70;
+    padding: 0px 5px;
+    border: 1px solid lightblue;
+    border-radius: 1rem;
+    cursor: pointer;
+    margin: 0.5rem;
+}
+
+#${BROWSER_LIBRARY_SELECT_BUTTON_ID}:hover {
+    color: black;
+    background: lightblue;
+    border-color: white;
+}
+#${BROWSER_LIBRARY_SELECT_CANCEL_BUTTON_ID} {
+    background: #09090970;
+    padding: 0px 5px;
+    border: 1px solid lightgray;
+    border-radius: 1rem;
+    cursor: pointer;
+    margin: 0.5rem;
+    box-shadow: 2px 2px 5px black;
+}
+#${BROWSER_LIBRARY_SELECT_CANCEL_BUTTON_ID}:hover {
+    background: lightgray;
+    border-color: black;
+    color: black;
+}
+
+#${BROWSER_LIBRARY_SELECTION_PANEL} {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid lightblue;
+    border-radius: 15px;
+    z-index: 2147483647;
+    position: fixed;
+    background: rgba(0, 0, 139, 0.5);
+    padding: 12px;
+    color: white;
+    -webkit-backdrop-filter: blur(5px);
+    backdrop-filter: blur(5px);
+}
+
+#${BROWSER_LIBRARY_SELECTION}:hover {
+    background: white;
+}
+
+#${BROWSER_LIBRARY_SELECTION} {
+    background: #d5d5d5;
+    color: black;
+    padding: 4px;
+    margin: 4px;
+    border: 1px solid darkblue;
+    font-family: monospace;
+    font-size: medium;
+    font-weight: normal;
+}
+.${BROWSER_LIBRARY_SELECTION_BUTTON_CLASS} {
+    color: white;
+    background: #00008b70;
+    border: 1px solid lightblue;
+    text-align: center;
+    vertical-align: middle;
+    margin: 4px 0px;
+    box-shadow: 2px 2px 5px black;
+    border-radius: 1rem;
+    padding: 4px;
+}
+.${BROWSER_LIBRARY_SELECTION_BUTTON_CLASS}:hover {
+    color: black;
+    background: lightblue;
+    border-color: white;
+}
+
+</style>`)
+        document.head.appendChild(style);
         addElement(label);
         window.requestAnimationFrame(updateTexts);
     });


### PR DESCRIPTION
- [x] added keyword_call_banner,
  - [x] docs
  - [x] tests
- [x] fixed missing presenter mode on some kw,
- [x] fixes support for variables in `Type`- / `Fill Secret` and muted the logging of those
- [x] improved styling on record selector,
  - [ ] added Drag&Drop to record selector
- [x] switched back to listenerv2 due to start_keyword needed
