### PR TITLE
Run macOS tests on different python versions in CI

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -100,11 +100,15 @@ jobs:
             node-version: 14.x
             shard: 3
           - os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.9"
             node-version: 16.x
             shard: 4
           - os: ubuntu-latest
-            python-version: "3.9"
+            python-version: "3.10"
+            node-version: 16.x
+            shard: 1
+          - os: macos-latest
+            python-version: "3.8"
             node-version: 16.x
             shard: 1
           - os: macos-latest
@@ -112,17 +116,9 @@ jobs:
             node-version: 16.x
             shard: 2
           - os: macos-latest
-            python-version: "3.9"
+            python-version: "3.10"
             node-version: 16.x
             shard: 3
-          - os: macos-latest
-            python-version: "3.9"
-            node-version: 16.x
-            shard: 4
-          - os: macos-latest
-            python-version: "3.9"
-            node-version: 16.x
-            shard: 1
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js


### PR DESCRIPTION
When dropping node 12 some accidental mistakes happened with the CI sharding configuration. This PR fixes them. (in the PR macOS no longer runs tests with (macos, node 16, python 3.9) three times, instead it correctly runs with node 16, macos and python[3.8, 3.9, 3.10])