### PR TITLE
Get Style with Pseudo Elements

### DIFF
--- a/Browser/base/librarycomponent.py
+++ b/Browser/base/librarycomponent.py
@@ -189,12 +189,10 @@ class LibraryComponent:
     def millisecs_to_timestr(self, timeout: float) -> str:
         return self.library.millisecs_to_timestr(timeout)
 
-    def resolve_secret(
-        self, secret_variable: Any, original_secret: Any, arg_name: str
-    ) -> str:
+    def resolve_secret(self, secret_variable: Any, arg_name: str) -> str:
         secret = self._replace_placeholder_variables(deepcopy(secret_variable))
         secret = self.decrypt_with_crypto_library(secret)
-        if secret == original_secret:
+        if secret == secret_variable:
             raise ValueError(
                 f"Direct assignment of values or variables as '{arg_name}' is not allowed. "
                 "Use special variable syntax ($var instead of ${var}) "

--- a/Browser/base/librarycomponent.py
+++ b/Browser/base/librarycomponent.py
@@ -48,6 +48,30 @@ class LibraryComponent:
         return self.library.playwright
 
     @property
+    def keyword_call_banner_add_style(self) -> str:
+        return self.library.scope_stack["keyword_call_banner_add_style"].get()
+
+    @property
+    def keyword_call_banner_add_style_stack(self) -> SettingsStack:
+        return self.library.scope_stack["keyword_call_banner_add_style"]
+
+    @keyword_call_banner_add_style_stack.setter
+    def keyword_call_banner_add_style_stack(self, stack: SettingsStack):
+        self.library.scope_stack["keyword_call_banner_add_style"] = stack
+
+    @property
+    def show_keyword_call_banner(self) -> bool:
+        return self.library.scope_stack["show_keyword_call_banner"].get()
+
+    @property
+    def show_keyword_call_banner_stack(self) -> SettingsStack:
+        return self.library.scope_stack["show_keyword_call_banner"]
+
+    @show_keyword_call_banner_stack.setter
+    def show_keyword_call_banner_stack(self, stack: SettingsStack):
+        self.library.scope_stack["show_keyword_call_banner"] = stack
+
+    @property
     def run_on_failure_keyword(self) -> DelayedKeyword:
         return self.library.scope_stack["run_on_failure"].get()
 

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -850,7 +850,6 @@ class Browser(DynamicCore):
         self._running_on_failure_keyword = False
         self.pause_on_failure: Set[str] = set()
         self._unresolved_promises: Set[Future] = set()
-        self.current_arguments = ()
         self._keyword_formatters: dict = {}
         self._current_loglevel: Optional[str] = None
         self.is_test_case_running = False
@@ -870,7 +869,9 @@ class Browser(DynamicCore):
         self.scope_stack["run_on_failure"] = SettingsStack(
             self._parse_run_on_failure_keyword(params["run_on_failure"]), self
         )
-        self.scope_stack["show_keyword_call_banner"] = SettingsStack(params["show_keyword_call_banner"], self)
+        self.scope_stack["show_keyword_call_banner"] = SettingsStack(
+            params["show_keyword_call_banner"], self
+        )
         self.scope_stack["keyword_call_banner_add_style"] = SettingsStack("", self)
 
     @property
@@ -1091,7 +1092,6 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
             or attrs["status"] == "NOT RUN"
         ):
             self._show_keyword_call(attrs)
-        self.current_arguments = tuple(attrs["args"])
         if "secret" in attrs["kwname"].lower() and attrs["libname"] == "Browser":
             self._set_logging(False)
 

--- a/Browser/keywords/browser_control.py
+++ b/Browser/keywords/browser_control.py
@@ -212,7 +212,7 @@ class Control(LibraryComponent):
 
         | =Arguments= | =Description= |
         | ``timeout`` | Timeout of it is for current playwright context and for new contexts. Supports Robot Framework [https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#time-format|time format] . Returns the previous value of the timeout. |
-        | ``scope``   | Scope defines the live time of that setting. Available values are ``Global``, ``Suite`` or ``Test``/``Task``. See `Scope Settings` for more details. |
+        | ``scope``   | Scope defines the live time of that setting. Available values are ``Global``, ``Suite`` or ``Test`` / ``Task``. See `Scope Settings` for more details. |
 
         Example:
         | ${old_timeout} =    `Set Browser Timeout`    1m 30 seconds
@@ -244,7 +244,7 @@ class Control(LibraryComponent):
 
         | =Arguments= | =Description= |
         | ``timeout`` | Assertion retry timeout will determine how long Browser library will retry an assertion to be true. |
-        | ``scope``   | Scope defines the live time of that setting. Available values are ``Global``, ``Suite`` or ``Test``/``Task``. See `Scope` for more details. |
+        | ``scope``   | Scope defines the live time of that setting. Available values are ``Global``, ``Suite`` or ``Test`` / ``Task``. See `Scope` for more details. |
 
         The other keyword `Set Browser timeout` controls how long Playwright
         will perform waiting in the node side for Elements to fulfill the
@@ -275,7 +275,7 @@ class Control(LibraryComponent):
 
         | =Arguments= | =Description= |
         | ``prefix``   | Prefix for all selectors. Prefix and selector will be separated by a single space. |
-        | ``scope``   | Scope defines the live time of that setting. Available values are ``Global``, ``Suite`` or ``Test``/``Task``. See `Scope` for more details. |
+        | ``scope``   | Scope defines the live time of that setting. Available values are ``Global``, ``Suite`` or ``Test`` / ``Task``. See `Scope` for more details. |
 
         Returns the previous value of the prefix.
 
@@ -295,7 +295,7 @@ class Control(LibraryComponent):
 
     @keyword(tags=("Setter", "Config"))
     def show_keyword_banner(
-        self, show: bool = True, style: str = ""
+        self, show: bool = True, style: str = "", scope: Scope = Scope.Suite
     ) -> Dict[str, Union[None, bool, str]]:
         """Controls if the keyword banner is shown on page or not.
 
@@ -308,7 +308,7 @@ class Control(LibraryComponent):
         | =Arguments= | =Description= |
         | ``show`` | If `True` banner is shown on page. If `False` banner is not shown on page. If `None` banner is shown on page only when running in presenter mode. |
         | ``style`` | Additional css styles to be applied to the banner. These styles are css settings and may override the existing ones for the banner. |
-
+        | ``scope``   | Scope defines the live time of that setting. Available values are ``Global``, ``Suite`` or ``Test`` / ``Task``. See `Scope` for more details. |
 
         Example:
         | Show Keyword Banner     True    top: 5px; bottom: auto; left: 5px; background-color: #00909077; font-size: 9px; color: black;   # Show banner on top left corner with custom styles
@@ -316,10 +316,10 @@ class Control(LibraryComponent):
 
         [https://forum.robotframework.org/t//4716|Comment >>]
         """
-        original_state = self.library.show_keyword_call_banner
-        original_style = self.library.keyword_call_banner_add_style
-        self.library.show_keyword_call_banner = show
-        self.library.keyword_call_banner_add_style = style
+        original_state = self.show_keyword_call_banner
+        original_style = self.keyword_call_banner_add_style
+        self.show_keyword_call_banner_stack.set(show, scope)
+        self.keyword_call_banner_add_style_stack.set(style, scope)
         if not show:
             self.library.set_keyword_call_banner()
         return {"show": original_state, "style": original_style}

--- a/Browser/keywords/getters.py
+++ b/Browser/keywords/getters.py
@@ -959,21 +959,27 @@ class Getters(LibraryComponent):
         [https://forum.robotframework.org/t//4281|Comment >>]
         """
         selector = self.presenter_mode(selector, self.strict_mode)
-        if key == "ALL":
-            key = None
+        if key == "ALL" or key is None:
+            key = ""
         with self.playwright.grpc_channel() as stub:
             response = stub.GetStyle(
-                Request().ElementStyle(selector=selector, styleKey=key, pseudo=pseudo_element, strict=self.strict_mode)
+                Request().ElementStyle(
+                    selector=selector,
+                    styleKey=key,
+                    pseudo=pseudo_element or "",
+                    strict=self.strict_mode,
+                )
             )
         parsed_response = json.loads(response.json)
         formatter = self.keyword_formatters.get(self.get_style)
-        if key is None and isinstance(parsed_response, dict):
+        logger.console(type(parsed_response))
+        if key == "" or isinstance(parsed_response, dict):
             if formatter:
                 logger.warn(
                     "Formatter is not supported by Get Style keyword with key 'ALL'."
                 )
             return dict_verify_assertion(
-                parsed_response,
+                DotDict(parsed_response),
                 assertion_operator,
                 assertion_expected,
                 "Computed style is",

--- a/Browser/keywords/interaction.py
+++ b/Browser/keywords/interaction.py
@@ -25,7 +25,6 @@ from ..utils import (
     get_abs_scroll_coordinates,
     get_rel_scroll_coordinates,
     keyword,
-    locals_to_params,
     logger,
 )
 from ..utils.data_types import (
@@ -185,10 +184,7 @@ class Interaction(LibraryComponent):
 
         [https://forum.robotframework.org/t//4338|Comment >>]
         """
-        originals = self._get_original_values(locals())
-        secret = self.resolve_secret(
-            secret, originals.get("secret") or secret, "secret"
-        )
+        secret = self.resolve_secret(secret, "secret")
         try:
             self._type_text(
                 selector,
@@ -200,23 +196,6 @@ class Interaction(LibraryComponent):
             )
         except Exception as e:
             raise Exception(str(e).replace(secret, "***"))
-
-    def _get_original_values(self, local_args: Dict[str, Any]) -> Dict[str, Any]:
-        originals = locals_to_params(local_args)
-        if not self.library.current_arguments:
-            return originals
-        named_args = False
-        for idx, val in enumerate(self.library.current_arguments):
-            if idx > len(originals):
-                break
-            if "=" in val and not named_args:
-                named_args = val.split("=", 1)[0] in originals
-            if named_args:
-                arg_name, arg_value = val.split("=", 1)
-                originals[arg_name] = arg_value
-            else:
-                originals[list(originals.keys())[idx]] = val
-        return originals
 
     @keyword(tags=("Setter", "PageContent"))
     def fill_secret(self, selector: str, secret: str, force: bool = False):
@@ -263,10 +242,7 @@ class Interaction(LibraryComponent):
 
         [https://forum.robotframework.org/t//4253|Comment >>]
         """
-        originals = self._get_original_values(locals())
-        secret = self.resolve_secret(
-            secret, originals.get("secret") or secret, "secret"
-        )
+        secret = self.resolve_secret(secret, "secret")
         try:
             self._fill_text(
                 selector,

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -751,9 +751,7 @@ class PlaywrightState(LibraryComponent):
                 f"storageState argument value '{storageState}' is not file, but it should be."
             )
         if "httpCredentials" in params and params["httpCredentials"] is not None:
-            secret = self.resolve_secret(
-                httpCredentials, params.get("httpCredentials"), "httpCredentials"
-            )
+            secret = self.resolve_secret(httpCredentials, "httpCredentials")
             params["httpCredentials"] = secret
         masked_params = self._mask_credentials(params.copy())
         logger.info(json.dumps(masked_params, default=str, indent=2))

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -891,7 +891,7 @@ class PlaywrightState(LibraryComponent):
     def get_browser_catalog(
         self,
         assertion_operator: Optional[AssertionOperator] = None,
-        assertion_expected: Any = None,
+        assertion_expected: Optional[Any] = None,
         message: Optional[str] = None,
     ) -> Dict:
         """Returns all browsers, open contexts in them and open pages in these contexts.

--- a/Browser/keywords/runonfailure.py
+++ b/Browser/keywords/runonfailure.py
@@ -36,7 +36,7 @@ class RunOnFailureKeywords(LibraryComponent):
         | =Arguments= | =Description= |
         | ``keyword`` | The name of a keyword that will be executed if a Browser keyword fails. It is possible to use any available keyword, including user keywords or keywords from other libraries. |
         | ``*args`` | The arguments to the keyword if any. |
-        | ``scope`` | Scope defines the live time of this setting. Available values are ``Global``, ``Suite`` or ``Test``/``Task``. See `Scope Settings` for more details. |
+        | ``scope`` | Scope defines the live time of this setting. Available values are ``Global``, ``Suite`` or ``Test`` / ``Task``. See `Scope Settings` for more details. |
 
         The initial keyword to use is set when `importing` the library, and
         the keyword that is used by default is `Take Screenshot`.

--- a/Browser/keywords/strict_mode.py
+++ b/Browser/keywords/strict_mode.py
@@ -22,7 +22,7 @@ class StrictMode(LibraryComponent):
 
         | =Arguments= | =Description= |
         | ``mode`` | When set to ``True``, keywords that are searching elements will use Playwright [https://playwright.dev/docs/api/class-page#page-query-selector|strict mode]. Keyword changes library strict mode value and keyword also return the previous strict mode value. |
-        | ``scope``   | Scope defines the live time of that setting. Available values are ``Global``, ``Suite`` or ``Test``/``Task``. See `Scope` for more details. |
+        | ``scope``   | Scope defines the live time of that setting. Available values are ``Global``, ``Suite`` or ``Test`` / ``Task``. See `Scope` for more details. |
 
 
         Example:

--- a/Browser/keywords/webapp_state.py
+++ b/Browser/keywords/webapp_state.py
@@ -30,7 +30,7 @@ class WebAppState(LibraryComponent):
         self,
         key: str,
         assertion_operator: Optional[AssertionOperator] = None,
-        assertion_expected: Any = None,
+        assertion_expected: Optional[Any] = None,
         message: Optional[str] = None,
     ) -> Any:
         """Get saved data from the local storage.
@@ -134,7 +134,7 @@ class WebAppState(LibraryComponent):
         self,
         key: str,
         assertion_operator: Optional[AssertionOperator] = None,
-        assertion_expected: Any = None,
+        assertion_expected: Optional[Any] = None,
     ) -> Any:
         """Get saved data from from session storage.
 

--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -624,6 +624,26 @@ class ConditionInputs(Enum):
 
 
 class Scope(Enum):
+    """Some keywords which manipulates library settings have a scope argument.
+    With that scope argument one can set the "live time" of that setting.
+    Available Scopes are: ``Global``, ``Suite`` and ``Test`` / ``Task``.
+    Is a scope finished, this scoped setting, like timeout, will no longer be used and the previous higher scope setting applies again.
+
+    Live Times:
+
+    - A ``Global`` scope will live forever until it is overwritten by another Global scope.
+      Or locally temporarily overridden by a more narrow scope.
+    - A ``Suite`` scope will locally override the Global scope and
+      live until the end of the Suite within it is set, or if it is overwritten
+      by a later setting with Global or same scope. 
+      Children suite does inherit the setting from the parent suite but also may have
+      its own local Suite setting that then will be inherited to its children suites.
+    - A ``Test`` or ``Task`` scope will be inherited from its parent suite but when set,
+      lives until the end of that particular test or task.
+    
+    A new set higher order scope will always remove the lower order scope which may be in charge.
+    So the setting of a Suite scope from a test, will set that scope to the robot file suite where
+    that test is and removes the Test scope that may have been in place."""
     Global = auto()
     Suite = auto()
     Test = auto()

--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -635,15 +635,16 @@ class Scope(Enum):
       Or locally temporarily overridden by a more narrow scope.
     - A ``Suite`` scope will locally override the Global scope and
       live until the end of the Suite within it is set, or if it is overwritten
-      by a later setting with Global or same scope. 
+      by a later setting with Global or same scope.
       Children suite does inherit the setting from the parent suite but also may have
       its own local Suite setting that then will be inherited to its children suites.
     - A ``Test`` or ``Task`` scope will be inherited from its parent suite but when set,
       lives until the end of that particular test or task.
-    
+
     A new set higher order scope will always remove the lower order scope which may be in charge.
     So the setting of a Suite scope from a test, will set that scope to the robot file suite where
     that test is and removes the Test scope that may have been in place."""
+
     Global = auto()
     Suite = auto()
     Test = auto()

--- a/atest/test/02_Content_Keywords/assertions.robot
+++ b/atest/test/02_Content_Keywords/assertions.robot
@@ -23,7 +23,7 @@ Get Attribute Names Does Not Support Formatter:
     Get Attribute Names    id=two    ==    id
     [Teardown]    Formatter TearDown
 
-Get Attribute Names Does Not Support Formatter:
+Get Attribute Names Does Not Support Formatter2:
     [Documentation]
     ...    LOG 1:*    DEBUG    GLOB:    Assertion polling statistics:*
     [Setup]    Go To    ${SPACES_URL}
@@ -45,14 +45,48 @@ InEqual
 
 Greater Than
     Get Style    //*[@id="progress"]    width    >    100
-    Get Style    //*[@id="progress"]    width    greater than    100
+    Get Style    id=progress    width    greater than    100
 
 Greater Or Equal
-    Get Style    //*[@id="progress"]    width    >=    400
+    Get Style    css=#progress    width    >=    400
 
 Less
     Get Style    //*[@id="progress"]    width    <    401
     Get Style    //*[@id="progress"]    width    less than    401
+
+Pseudo Elements and Keyword Banner Activated Scope Suite
+    Show Keyword Banner    show=True    scope=Suite
+    Get Title
+    Get Style    body    bottom    ==    5px    pseudo_element=::before
+    Get Style    body    background-color    ==    rgba(0, 0, 139, 0.565)    pseudo_element=::before
+    Get Style    body    font-size    ==    13px    pseudo_element=::before
+    Get Style    body    color    ==    rgb(255, 255, 255)    pseudo_element=::before
+
+Pseudo Elements and Keyword Banner Styled Scope Test
+    Show Keyword Banner    show=True    style=top: 5px; bottom: auto; left: 5px; background-color: #00909077; font-size: 9px; color: black;    scope=Test
+    Get Title
+    Get Style    body    top    ==    5px    pseudo_element=::before
+    Get Style    body    background-color    ==    rgba(0, 144, 144, 0.467)    pseudo_element=::before
+    Get Style    body    font-size    ==    9px    pseudo_element=::before
+    Get Style    body    color    ==    rgb(0, 0, 0)    pseudo_element=::before
+
+Pseudo Elements and Keyword Banner Off Scope Test
+    Show Keyword Banner    show=False    scope=Test
+    Get Title
+    Get Style    body    top    ==    auto    pseudo_element=::before
+    Get Style    body    background-color    ==    rgba(0, 0, 0, 0)    pseudo_element=::before
+    Get Style    body    font-size    ==    16px    pseudo_element=::before
+    Get Style    body    color    ==    rgb(0, 0, 0)    pseudo_element=::before
+    Get Style    body    content    ==    none    pseudo_element=::before
+    
+
+Pseudo Elements and Keyword Banner Scope Test
+    Get Title
+    Get Style    body    bottom    ==    5px    pseudo_element=::before
+    Get Style    body    background-color    ==    rgba(0, 0, 139, 0.565)    pseudo_element=::before
+    Get Style    body    font-size    ==    13px    pseudo_element=::before
+    Get Style    body    color    ==    rgb(255, 255, 255)    pseudo_element=::before
+    Show Keyword Banner    show=False    scope=Suite
 
 Contains
     Get Title    *=    Page

--- a/atest/test/02_Content_Keywords/assertions.robot
+++ b/atest/test/02_Content_Keywords/assertions.robot
@@ -69,6 +69,8 @@ Pseudo Elements and Keyword Banner Styled Scope Test
     Get Style    body    background-color    ==    rgba(0, 144, 144, 0.467)    pseudo_element=::before
     Get Style    body    font-size    ==    9px    pseudo_element=::before
     Get Style    body    color    ==    rgb(0, 0, 0)    pseudo_element=::before
+    Get Style    body    ALL    pseudo_element=::before
+    Get Style    body    ${None}    pseudo_element=::before
 
 Pseudo Elements and Keyword Banner Off Scope Test
     Show Keyword Banner    show=False    scope=Test

--- a/node/playwright-wrapper/getters.ts
+++ b/node/playwright-wrapper/getters.ts
@@ -242,11 +242,9 @@ export async function getStyle(request: Request.ElementStyle, state: PlaywrightS
     logger.info('Getting css of element on page');
     const locator = await findLocator(state, selector, strictMode, undefined, true);
     const result = await locator.evaluate((element: Element, option) => {
-        const pseudoElement = option.pseudoElement;
-        const styleKey = option.styleKey;
-        const cssStyleDeclaration = window.getComputedStyle(element, pseudoElement);
-        if (styleKey) {
-            return cssStyleDeclaration.getPropertyValue(styleKey);
+        const cssStyleDeclaration = window.getComputedStyle(element, option.pseudoElement);
+        if (option.styleKey) {
+            return cssStyleDeclaration.getPropertyValue(option.styleKey);
         } else {
             return Object.fromEntries(
                 Array.from(cssStyleDeclaration).map((key) => [key, cssStyleDeclaration.getPropertyValue(key)]),

--- a/node/playwright-wrapper/getters.ts
+++ b/node/playwright-wrapper/getters.ts
@@ -231,24 +231,30 @@ export async function getElementStates(
     return jsonResponse(JSON.stringify(states), 'Returned state.');
 }
 
-export async function getStyle(request: Request.ElementSelector, state: PlaywrightState): Promise<Response.Json> {
+export async function getStyle(request: Request.ElementStyle, state: PlaywrightState): Promise<Response.Json> {
     const selector = request.getSelector();
+    const option = {
+        styleKey: request.getStylekey() || null,
+        pseudoElement: request.getPseudo() || null,
+    };
     const strictMode = request.getStrict();
 
     logger.info('Getting css of element on page');
     const locator = await findLocator(state, selector, strictMode, undefined, true);
     await locator.elementHandle();
-    const result = await locator.evaluate(function (element: Element) {
-        const rawStyle = window.getComputedStyle(element);
-        const mapped: Record<string, string> = {};
-        // This is necessary because JSON.stringify doesn't handle CSSStyleDeclarations correctly
-        for (let i = 0; i < rawStyle.length; i++) {
-            const name = rawStyle[i];
-            mapped[name] = rawStyle.getPropertyValue(name);
+    const result = await locator.evaluate((element: Element, option) => {
+        const pseudoElement = option.pseudoElement;
+        const styleKey = option.styleKey;
+        const cssStyleDeclaration = window.getComputedStyle(element, pseudoElement);
+        if (styleKey) {
+            return cssStyleDeclaration.getPropertyValue(styleKey);
+        } else {
+            return Object.fromEntries(
+                Array.from(cssStyleDeclaration).map((key) => [key, cssStyleDeclaration.getPropertyValue(key)]),
+            );
         }
-        return JSON.stringify(mapped);
-    });
-    return jsonResponse(result, 'Style get successfully.');
+    }, option);
+    return jsonResponse(JSON.stringify(result), 'Style get successfully.');
 }
 
 export async function getViewportSize(page: Page): Promise<Response.Json> {

--- a/node/playwright-wrapper/getters.ts
+++ b/node/playwright-wrapper/getters.ts
@@ -241,7 +241,6 @@ export async function getStyle(request: Request.ElementStyle, state: PlaywrightS
 
     logger.info('Getting css of element on page');
     const locator = await findLocator(state, selector, strictMode, undefined, true);
-    await locator.elementHandle();
     const result = await locator.evaluate((element: Element, option) => {
         const pseudoElement = option.pseudoElement;
         const styleKey = option.styleKey;

--- a/protobuf/playwright.proto
+++ b/protobuf/playwright.proto
@@ -243,6 +243,13 @@ message Request {
     bool allElements = 4;
     bool strict = 5;
   }
+
+  message ElementStyle {
+    string selector = 1;
+    string pseudo = 2;
+    string styleKey = 3;
+    bool strict = 4;
+  }
 }
 
 message Types {
@@ -411,7 +418,7 @@ service  Playwright {
   rpc GetPageState(Request.Empty) returns (Response.JavascriptExecutionResult);
   rpc SetViewportSize(Request.Viewport) returns (Response.Empty);
   /* Gets an elements computed style */
-  rpc GetStyle(Request.ElementSelector) returns (Response.Json);
+  rpc GetStyle(Request.ElementStyle) returns (Response.Json);
   /* Gets elements x, y coordinates and width, height as json object */ 
   rpc GetBoundingBox(Request.ElementSelector) returns (Response.Json);
   /* Makes a `fetch` request in the browser */


### PR DESCRIPTION
Get Style is now able to return any style property, not only those included in the dictionary.
Also Pseudo Elements are supported.


Also added:
- Added Scope to `Show Keyword Banner`

Also fixed:
- Fixed Logging issue with `Type/Fill Secret`
- Fixed Docs of Scope
- Fixed 'none' string issue with Assertions
