### PR TITLE
improved Take Screenshot to be able not to log and to return a Screen…

### DIFF
--- a/Browser/keywords/browser_control.py
+++ b/Browser/keywords/browser_control.py
@@ -269,7 +269,7 @@ class Control(LibraryComponent):
             try:
                 screenshot_path.unlink()
             except Exception:
-                pass
+                logger.trace(f"Could not delete screenshot '{screenshot_path}'.")
 
     def _log_image_link(self, file_path: str) -> None:
         relative_path = get_link_path(file_path, self.outputdir)

--- a/Browser/keywords/browser_control.py
+++ b/Browser/keywords/browser_control.py
@@ -14,6 +14,7 @@
 import base64
 import json
 import os
+import uuid
 from collections.abc import Iterable
 from datetime import timedelta
 from pathlib import Path
@@ -24,7 +25,13 @@ from robot.utils import get_link_path
 from ..base import LibraryComponent
 from ..generated.playwright_pb2 import Request
 from ..utils import Scope, keyword, logger
-from ..utils.data_types import BoundingBox, Permission, ScreenshotFileTypes
+from ..utils.data_types import (
+    BoundingBox,
+    Permission,
+    ScreenshotFileTypes,
+    ScreenshotReturnType,
+)
+from ..utils.deprecated import convert_pos_args_to_named
 
 
 class Control(LibraryComponent):
@@ -85,36 +92,55 @@ class Control(LibraryComponent):
             if not path.with_suffix(f".{fileType}").is_file():
                 return path
 
+    old_take_screenshot_args = {
+        "fullPage": bool,
+        "fileType": ScreenshotFileTypes,
+        "quality": Optional[int],
+        "timeout": Optional[timedelta],
+        "crop": Optional[BoundingBox],
+        "disableAnimations": bool,
+        "mask": Union[List[str], str],
+        "omitBackground": bool,
+    }
+
     @keyword(tags=("PageContent",))
     def take_screenshot(
         self,
-        filename: str = "robotframework-browser-screenshot-{index}",
+        filename: Optional[str] = "robotframework-browser-screenshot-{index}",
         selector: Optional[str] = None,
-        fullPage: bool = False,
-        fileType: ScreenshotFileTypes = ScreenshotFileTypes.png,
-        quality: Optional[int] = None,
-        timeout: Optional[timedelta] = None,
+        *deprecated_pos_args,
         crop: Optional[BoundingBox] = None,
         disableAnimations: bool = False,
+        fileType: ScreenshotFileTypes = ScreenshotFileTypes.png,
+        fullPage: bool = False,
+        log_screenshot: bool = True,
         mask: Union[List[str], str] = "",
         omitBackground: bool = False,
-    ) -> str:
+        quality: Optional[int] = None,
+        return_as: ScreenshotReturnType = ScreenshotReturnType.path_string,
+        timeout: Optional[timedelta] = None,
+    ) -> Union[str, bytes, Path]:
         """Takes a screenshot of the current window or element and saves it to disk.
 
         | =Arguments= | =Description= |
-        | ``filename`` | Filename into which to save. The file will be saved into the robot framework  ${OUTPUTDIR}/browser/screenshot directory by default, but it can overwritten by providing  custom path or filename. String ``{index}`` in filename will be replaced with a rolling  number. Use this to not override filenames. If filename equals to EMBED (case insensitive),  then screenshot is embedded as Base64 image to the log.html. The image is saved temporally  to the disk and warning is displayed if removing the temporary file fails. The ${OUTPUTDIR}/browser/ is removed at the first suite startup. |
+        | ``filename`` | Filename into which to save. The file will be saved into the robot framework  ${OUTPUTDIR}/browser/screenshot directory by default, but it can be overwritten by providing custom path or filename. String ``{index}`` in filename will be replaced with a rolling  number. Use this to not override filenames. If filename equals to EMBED (case insensitive) or ${NONE},  then screenshot is embedded as Base64 image to the log.html. The image is saved temporally  to the disk and warning is displayed if removing the temporary file fails. The ${OUTPUTDIR}/browser/ is removed at the first suite startup. |
         | ``selector`` | Take a screenshot of the element matched by selector. See the `Finding elements` section for details about the selectors. If not provided take a screenshot of current viewport. |
-        | ``fullPage`` | When True, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to False. |
-        | ``fileType`` | <"png"|"jpeg"> Specify screenshot type, defaults to png. |
-        | ``quality`` | The quality of the image, between 0-100. Not applicable to png images. |
-        | ``timeout`` | Maximum time how long taking screenshot can last, defaults to library timeout. Supports Robot Framework time format, like 10s or 1 min, pass 0 to disable timeout. The default value can be changed by using the `Set Browser Timeout` keyword. |
         | ``crop`` | Crops the taken screenshot to the given box. It takes same dictionary as returned from `Get BoundingBox`. Cropping only works on page screenshot, so if no selector is given. |
         | ``disableAnimations`` | When set to ``True``, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment depending on their duration:  - finite animations are fast-forwarded to completion, so they'll fire transitionend event.  - infinite animations are canceled to initial state, and then played over after the screenshot. |
+        | ``fileType`` | <"png"|"jpeg"> Specify screenshot type, defaults to png. |
+        | ``fullPage`` | When True, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to False. |
+        | ``log_screenshot`` | When set to ``False`` the screenshot is taken but not logged into log.html. |
         | ``mask`` | Specify selectors that should be masked when the screenshot is taken. Masked elements will be overlayed with a pink box ``#FF00FF`` that completely covers its bounding box. Argument can take a single selector string or a list of selector strings if multiple different elements should be masked. |
         | ``omitBackground`` | Hides default white background and allows capturing screenshots with transparency. Not applicable to jpeg images. |
+        | ``quality`` | The quality of the image, between 0-100. Not applicable to png images. |
+        | ``return_as`` | Defines what this keyword returns. Possible values are documented in `ScreenshotReturnType`. It can be either a path to the screenshot file as string or Path object, or the image data as bytes or base64 encoded string. |
+        | ``timeout`` | Maximum time how long taking screenshot can last, defaults to library timeout. Supports Robot Framework time format, like 10s or 1 min, pass 0 to disable timeout. The default value can be changed by using the `Set Browser Timeout` keyword. |
 
         Keyword uses strict mode if selector is defined. See `Finding elements` for more details
         about strict mode.
+
+        Old deprecated argument order:
+        ``fullPage``, ``fileType``, ``quality``, ``timeout``, ``crop``, ``disableAnimations``, ``mask``, ``omitBackground``
 
         Example
         | `Take Screenshot`                                 # Takes screenshot from page with default filename
@@ -125,84 +151,147 @@ class Control(LibraryComponent):
 
         [https://forum.robotframework.org/t//4337|Comment >>]
         """
-        if self._is_embed(filename):
-            logger.debug("Embedding image to log.html.")
-        else:
-            logger.debug(f"Using {filename} to take screenshot.")
+        pos_params = convert_pos_args_to_named(
+            deprecated_pos_args,
+            self.old_take_screenshot_args,
+            "Take Screenshot",
+            " Will be removed end of 2023.",
+        )
+        fullPage = pos_params.get("fullPage", fullPage)
+        fileType = pos_params.get("fileType", fileType)
+        quality = pos_params.get("quality", quality)
+        timeout = pos_params.get("timeout", timeout)
+        crop = pos_params.get("crop", crop)
+        disableAnimations = pos_params.get("disableAnimations", disableAnimations)
+        mask = pos_params.get("mask", mask)
+        omitBackground = pos_params.get("omitBackground", omitBackground)
+        file_name = (
+            uuid.uuid4().hex
+            if filename is None or self._is_embed(filename)
+            else filename
+        )
         string_path_no_extension = str(
-            self._get_screenshot_path(filename, fileType.name)
+            self._get_screenshot_path(file_name, fileType.name)
         )
         with self.playwright.grpc_channel() as stub:
-            options = {
-                "path": f"{string_path_no_extension}.{fileType.name}",
-                "fileType": fileType.name,
-                "fullPage": fullPage,
-                "timeout": int(self.get_timeout(timeout)),
-                "omitBackground": omitBackground,
-            }
-            if mask:
-                mask_selectors: Optional[List[str]]
-                if isinstance(mask, str):
-                    mask_selectors = [self.resolve_selector(mask)]
-                elif isinstance(mask, Iterable):
-                    mask_selectors = [self.resolve_selector(str(s)) for s in mask]
-                else:
-                    raise ValueError(
-                        f"'mask' argument is neither string nor list of string. It is {type(mask)}"
-                    )
-            else:
-                mask_selectors = None
-
-            if quality is not None:
-                options["quality"] = max(min(100, quality), 0)
-            if disableAnimations:
-                options["animations"] = "disabled"
-            if crop:
-                options["clip"] = crop
+            options = self._create_screenshot_options(
+                crop,
+                disableAnimations,
+                fileType,
+                fullPage,
+                omitBackground,
+                quality,
+                string_path_no_extension,
+                timeout,
+            )
             response = stub.TakeScreenshot(
                 Request().ScreenshotOptions(
                     selector=self.resolve_selector(selector) or "",
-                    mask=json.dumps(mask_selectors),
+                    mask=json.dumps(self._get_mask_selectors(mask)),
                     options=json.dumps(options),
                     strict=self.strict_mode,
                 )
             )
             logger.debug(response.log)
-            file_path = response.body
+            screenshot_path_str = response.body
+            screenshot_path = Path(screenshot_path_str)
+            if (log_screenshot and self._is_embed(filename)) or return_as in (
+                ScreenshotReturnType.bytes,
+                ScreenshotReturnType.base64,
+            ):
+                with screenshot_path.open("rb") as png_file:
+                    screenshot_bytes = png_file.read()
+                    base64_screenshot = base64.b64encode(screenshot_bytes)
+                if log_screenshot and self._is_embed(filename):
+                    logger.debug("Embedding image to log.html.")
+                    self._embed_to_log(base64_screenshot)
 
-            if self._is_embed(filename):
-                return self._embed_to_log(file_path)
-            return self._log_image_link(file_path)
+            if log_screenshot and not self._is_embed(filename):
+                self._log_image_link(screenshot_path_str)
 
-    def _log_image_link(self, file_path: str) -> str:
+            self._unlink_screenshot(filename, return_as, screenshot_path)
+            if return_as is ScreenshotReturnType.path_string:
+                return "EMBED" if self._is_embed(filename) else screenshot_path_str
+            if return_as is ScreenshotReturnType.path:
+                return screenshot_path
+            if return_as is ScreenshotReturnType.bytes:
+                return screenshot_bytes
+            if return_as is ScreenshotReturnType.base64:
+                return base64_screenshot.decode()
+
+    def _create_screenshot_options(
+        self,
+        crop,
+        disableAnimations,
+        fileType,
+        fullPage,
+        omitBackground,
+        quality,
+        string_path_no_extension,
+        timeout,
+    ):
+        options = {
+            "path": f"{string_path_no_extension}.{fileType.name}",
+            "fileType": fileType.name,
+            "fullPage": fullPage,
+            "timeout": int(self.get_timeout(timeout)),
+            "omitBackground": omitBackground,
+        }
+        if quality is not None:
+            options["quality"] = max(min(100, quality), 0)
+        if disableAnimations:
+            options["animations"] = "disabled"
+        if crop:
+            options["clip"] = crop
+        return options
+
+    def _get_mask_selectors(self, mask):
+        if mask:
+            mask_selectors: Optional[List[str]]
+            if isinstance(mask, str):
+                mask_selectors = [self.resolve_selector(mask)]
+            elif isinstance(mask, Iterable):
+                mask_selectors = [self.resolve_selector(str(s)) for s in mask]
+            else:
+                raise ValueError(
+                    f"'mask' argument is neither string nor list of string. It is {type(mask)}"
+                )
+        else:
+            mask_selectors = None
+        return mask_selectors
+
+    def _unlink_screenshot(self, filename, return_as, screenshot_path):
+        if (
+            filename is None
+            or self._is_embed(filename)
+            or return_as in (ScreenshotReturnType.bytes, ScreenshotReturnType.base64)
+        ):
+            try:
+                screenshot_path.unlink()
+            except Exception:
+                pass
+
+    def _log_image_link(self, file_path: str) -> None:
         relative_path = get_link_path(file_path, self.outputdir)
         logger.info(
             '</td></tr><tr><td colspan="3">'
             f'<a href="{relative_path}"><img src="{relative_path}" width="800px"></a>',
             html=True,
         )
-        return file_path
 
-    def _embed_to_log(self, file_path) -> str:
-        png = Path(file_path)
-        with png.open("rb") as png_file:
-            encoded_string = base64.b64encode(png_file.read())
+    def _embed_to_log(self, base64_screenshot: bytes) -> str:
         # log statement is copied from:
         # https://github.com/robotframework/SeleniumLibrary/blob/master/src/SeleniumLibrary/keywords/screenshot.py
         logger.info(
             '</td></tr><tr><td colspan="3">'
             '<img alt="screenshot" class="robot-seleniumlibrary-screenshot" '
-            f'src="data:image/png;base64,{encoded_string.decode()}" width="900px">',
+            f'src="data:image/png;base64,{base64_screenshot.decode()}" width="900px">',
             html=True,
         )
-        try:
-            png.unlink()
-        except Exception:
-            logger.warn(f"Could not remove {png}")
         return "EMBED"
 
-    def _is_embed(self, filename: str) -> bool:
-        return True if filename.upper() == "EMBED" else False
+    def _is_embed(self, filename: Optional[str]) -> bool:
+        return filename is None or filename.upper() == "EMBED"
 
     @keyword(tags=("Setter", "Config"))
     def set_browser_timeout(

--- a/Browser/keywords/browser_control.py
+++ b/Browser/keywords/browser_control.py
@@ -279,7 +279,7 @@ class Control(LibraryComponent):
         relative_path = get_link_path(file_path, self.outputdir)
         logger.info(
             '</td></tr><tr><td colspan="3">'
-            f'<a href="{relative_path}" target="_blank"><img src="{relative_path}" width="800px"></a>',
+            f'<a href="{relative_path}" target="_blank"><img src="{relative_path}" width="800px"/></a>',
             html=True,
         )
 
@@ -290,7 +290,7 @@ class Control(LibraryComponent):
         logger.info(
             '</td></tr><tr><td colspan="3">'
             '<img alt="screenshot" '
-            f'src="data:image/png;base64,{base64_screenshot.decode()}" width="900px">',
+            f'src="data:image/png;base64,{base64_screenshot.decode()}" width="900px"/>',
             html=True,
         )
         return "EMBED"

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -20,7 +20,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from uuid import uuid4
 
 from assertionengine import AssertionOperator, verify_assertion
-from robot.running.arguments.typeconverters import TypeConverter
 from robot.utils import get_link_path
 
 from ..assertion_engine import with_assertion_polling
@@ -46,6 +45,7 @@ from ..utils import (
     locals_to_params,
     logger,
 )
+from ..utils.deprecated import convert_pos_args_to_named
 
 
 class PlaywrightState(LibraryComponent):
@@ -387,19 +387,12 @@ class PlaywrightState(LibraryComponent):
         [https://forum.robotframework.org/t/comments-for-new-browser/4306|Comment >>]
         """
         params = locals_to_params(locals())
-        old_args_list = list(self.old_new_browser_args.items())
-        pos_params = {}
-        for index, pos_arg in enumerate(deprecated_pos_args):
-            argument_name = old_args_list[index][0]
-            argument_type = old_args_list[index][1]
-            converted_pos = TypeConverter.converter_for(argument_type).convert(
-                argument_name, pos_arg
-            )
-            pos_params[argument_name] = converted_pos
-        if pos_params:
-            logger.warn(
-                "Deprecated positional arguments are used in 'New Browser'. Please use named arguments instead."
-            )
+        pos_params = convert_pos_args_to_named(
+            deprecated_pos_args,
+            self.old_new_browser_args,
+            "New Browser",
+            " Will be removed after March 2023.",
+        )
         params = {**pos_params, **params}
         parameter_hash = self._get_parameter_hash(params)
         existing_browser_id = self._switch_to_existing_browser(
@@ -566,20 +559,12 @@ class PlaywrightState(LibraryComponent):
         """
         params = locals_to_params(locals())
         params["viewport"] = copy(viewport)
-        old_args_list = list(self.old_new_context_args.items())
-        pos_params = {}
-        for index, pos_arg in enumerate(deprecated_pos_args):
-            argument_name = old_args_list[index][0]
-            argument_type = old_args_list[index][1]
-            converted_pos = TypeConverter.converter_for(argument_type).convert(
-                argument_name, pos_arg
-            )
-            pos_params[argument_name] = converted_pos
-        if pos_params:
-            logger.warn(
-                "Deprecated positional arguments are used in 'New Context'. "
-                "Please use named arguments instead. Will be removed after March 2023."
-            )
+        pos_params = convert_pos_args_to_named(
+            deprecated_pos_args,
+            self.old_new_context_args,
+            "New Context",
+            " Will be removed after March 2023.",
+        )
         params = {**pos_params, **params}
         trace_file = str(Path(self.outputdir, tracing).resolve()) if tracing else ""
         params = self._set_context_options(params, httpCredentials, storageState)
@@ -725,19 +710,12 @@ class PlaywrightState(LibraryComponent):
         """
         params = locals_to_params(locals())
         params["viewport"] = copy(viewport)
-        old_args_list = list(self.old_new_perse_context_args.items())
-        pos_params = {}
-        for index, pos_arg in enumerate(deprecated_pos_args):
-            argument_name = old_args_list[index][0]
-            argument_type = old_args_list[index][1]
-            converted_pos = TypeConverter.converter_for(argument_type).convert(
-                argument_name, pos_arg
-            )
-            pos_params[argument_name] = converted_pos
-        if pos_params:
-            logger.warn(
-                "Deprecated positional arguments are used in 'New Persistent Context'. Please use named arguments instead."
-            )
+        pos_params = convert_pos_args_to_named(
+            deprecated_pos_args,
+            self.old_new_perse_context_args,
+            "New Persistent Context",
+            " Will be removed after March 2023.",
+        )
         params = {**pos_params, **params}
         trace_file = Path(self.outputdir, tracing).resolve() if tracing else ""
         params = self._set_browser_options(params, browser, channel, slowMo, timeout)

--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -548,6 +548,21 @@ class ScreenshotFileTypes(Enum):
     jpeg = auto()
 
 
+class ScreenshotReturnType(Enum):
+    """Enum that defines what `Take Screenshot` keyword returns.
+
+    - ``path`` returns the path to the screenshot file as ``pathlib.Path`` object.
+    - ``path_string`` returns the path to the screenshot file as string.
+    - ``bytes`` returns the screenshot itself as bytes.
+    - ``base64`` returns the screenshot itself as base64 encoded string.
+    """
+
+    path = auto()
+    path_string = auto()
+    bytes = auto()
+    base64 = auto()
+
+
 class PageLoadStates(Enum):
     """Enum that defines available page load states."""
 

--- a/atest/library/screenshot.py
+++ b/atest/library/screenshot.py
@@ -1,6 +1,8 @@
-from PIL import Image
+import base64
+from io import BytesIO
+from PIL import Image, ImageChops
 from typing import Tuple
-
+from robot.api import logger
 
 def get_image_size(img_path: str) -> Tuple[int]:
     im: Image.Image = Image.open(img_path)
@@ -12,3 +14,19 @@ def get_pixel_color(img_path: str, x: int, y: int) -> Tuple[int, int]:
     im: Image.Image = Image.open(img_path)
     pix = im.load()
     return pix[x,y]
+
+def compare_images(img1_path: str, img2_bytes: bytes) -> bool:
+    """Returns True if the images are the same, False otherwise"""
+    im1: Image.Image = Image.open(img1_path).convert('RGB')
+    im2: Image.Image = Image.open(BytesIO(img2_bytes)).convert('RGB')
+    diff: Image.Image = ImageChops.difference(im1, im2)
+    buffered = BytesIO()
+    diff.save(buffered, format="PNG")
+    img_str = base64.b64encode(buffered.getvalue()).decode()
+    logger.info(
+            '</td></tr><tr><td colspan="3">'
+            '<img alt="screenshot" class="robot-seleniumlibrary-screenshot" '
+            f'src="data:image/png;base64,{img_str}" width="900px">',
+            html=True,
+        )
+    assert diff.getbbox() is None

--- a/atest/test/02_Content_Keywords/screenshot.robot
+++ b/atest/test/02_Content_Keywords/screenshot.robot
@@ -96,8 +96,8 @@ Screenshotting Without Path
 
 Screenshot Filename Incrementation
     [Documentation]
-    ...    LOG 1:3    </td></tr><tr><td colspan="3"><a href="test_screenshot_1.png"><img src="test_screenshot_1.png" width="800px"></a>
-    ...    LOG 2:3    </td></tr><tr><td colspan="3"><a href="test_screenshot_2.png"><img src="test_screenshot_2.png" width="800px"></a>
+    ...    LOG 1:3    </td></tr><tr><td colspan="3"><a href="test_screenshot_1.png" target="_blank"><img src="test_screenshot_1.png" width="800px"/></a>
+    ...    LOG 2:3    </td></tr><tr><td colspan="3"><a href="test_screenshot_2.png" target="_blank"><img src="test_screenshot_2.png" width="800px"/></a>
     Take Screenshot    ${TestScreenshot}_{index}
     Take Screenshot    ${TestScreenshot}_{index}
     File Should Exist    ${TestScreenshot}_1.png
@@ -106,14 +106,14 @@ Screenshot Filename Incrementation
 
 Embed ScreenShot To Log.html File
     [Documentation]
-    ...    LOG 1:4    STARTS: </td></tr><tr><td colspan="3"><img alt="screenshot" class="robot-seleniumlibrary-screenshot" src="data:image/png;base64
+    ...    LOG 1:4    STARTS: </td></tr><tr><td colspan="3"><img alt="screenshot" src="data:image/png;base64
     ${path} =    Take Screenshot    EMBED
     Should Not Exist    ${OUTPUT_DIR}/EMBED*
     Should Be Equal    ${path}    EMBED
 
 Embed Element Picture To Log.html File
     [Documentation]
-    ...    LOG 1:*    STARTS: </td></tr><tr><td colspan="3"><img alt="screenshot" class="robot-seleniumlibrary-screenshot" src="data:image/png;base64
+    ...    LOG 1:*    STARTS: </td></tr><tr><td colspan="3"><img alt="screenshot" src="data:image/png;base64
     ${path} =    Take Screenshot    EMbeD    selector=\#username_field
     Should Not Exist    ${OUTPUT_DIR}/EM??D*
     Should Be Equal    ${path}    EMBED

--- a/atest/test/02_Content_Keywords/screenshot.robot
+++ b/atest/test/02_Content_Keywords/screenshot.robot
@@ -183,3 +183,38 @@ Screenshot With Omit Background
     ${color} =    Get Pixel Color    ${path}    ${width//2}    ${height//2}
     Should Be Equal    ${color}    ${{(0,0,0,0)}}
     [Teardown]    Remove File    ${path}
+
+Screenshot Returns Base64 And Path
+    [Timeout]    10 minutes
+    ${path} =    Take Screenshot    return_as=path
+    ${base64} =    Take Screenshot    return_as=base64
+    Type Text    id=username_field    Hello
+    ${base64_diff} =    Take Screenshot    return_as=base64
+    Should Be True    isinstance($path, pathlib.Path)
+    ${bytes} =    Evaluate    base64.b64decode($base64)
+    Compare Images    ${path.absolute().resolve()}    ${bytes}
+    Should Not Be Equal    ${base64}    ${base64_diff}
+    ${bytes_diff} =    Evaluate    base64.b64decode($base64_diff)
+    TRY
+        Compare Images    ${path}    ${bytes_diff}
+        Fail    Should have failed
+    EXCEPT    AssertionError
+        Log    correct error
+    END
+
+Screenshot Returns Bytes And Path String
+    [Timeout]    10 minutes
+    ${path} =    Take Screenshot    return_as=path_string
+    ${bytes} =    Take Screenshot    return_as=bytes
+    Type Text    id=username_field    Hello
+    ${bytes_diff} =    Take Screenshot    return_as=bytes
+    Should Be True    isinstance($path, str)
+    Should Be True    isinstance($bytes, bytes)
+    Compare Images    ${path}    ${bytes}
+    Should Not Be Equal    ${bytes}    ${bytes_diff}
+    TRY
+        Compare Images    ${path}    ${bytes_diff}
+        Fail    Should have failed
+    EXCEPT    AssertionError
+        Log    correct error
+    END

--- a/atest/test/02_Content_Keywords/screenshot.robot
+++ b/atest/test/02_Content_Keywords/screenshot.robot
@@ -96,8 +96,8 @@ Screenshotting Without Path
 
 Screenshot Filename Incrementation
     [Documentation]
-    ...    LOG 1:4    </td></tr><tr><td colspan="3"><a href="test_screenshot_1.png"><img src="test_screenshot_1.png" width="800px"></a>
-    ...    LOG 2:4    </td></tr><tr><td colspan="3"><a href="test_screenshot_2.png"><img src="test_screenshot_2.png" width="800px"></a>
+    ...    LOG 1:3    </td></tr><tr><td colspan="3"><a href="test_screenshot_1.png"><img src="test_screenshot_1.png" width="800px"></a>
+    ...    LOG 2:3    </td></tr><tr><td colspan="3"><a href="test_screenshot_2.png"><img src="test_screenshot_2.png" width="800px"></a>
     Take Screenshot    ${TestScreenshot}_{index}
     Take Screenshot    ${TestScreenshot}_{index}
     File Should Exist    ${TestScreenshot}_1.png

--- a/utest/test_run_on_failure.py
+++ b/utest/test_run_on_failure.py
@@ -39,8 +39,13 @@ def test_library_keyword(browser: Browser.Browser):
     keyword = browser._parse_run_on_failure_keyword("tAke sCreenshot  filename.png  //button  True")
     assert keyword.name == "take_screenshot"
     assert keyword.original_name == "tAke sCreenshot"
-    assert keyword.args == ("filename.png", "//button", True)
+    assert keyword.args == ("filename.png", "//button", 'True')
     assert keyword.kwargs == {}
+    keyword = browser._parse_run_on_failure_keyword("tAke sCreenshot  filename.png  //button  fullPage=True")
+    assert keyword.name == "take_screenshot"
+    assert keyword.original_name == "tAke sCreenshot"
+    assert keyword.args == ("filename.png", "//button")
+    assert keyword.kwargs == {'fullPage': True}
 
 
 def test_library_keyword_with_named_args(browser: Browser.Browser):


### PR DESCRIPTION
Take Screenshot got two more arguments:
- return_as: defines wether the keyword returns a path or image
- log_screenshot: defines wether the screenshot is logged to log.html or not

Also changes positional_or_named arguments to named_only arguments