### PR TITLE
Topic/wait for request response with proper reg exp

### DIFF
--- a/Browser/keywords/webapp_state.py
+++ b/Browser/keywords/webapp_state.py
@@ -86,7 +86,7 @@ class WebAppState(LibraryComponent):
 
         [https://forum.robotframework.org/t//4302|Comment >>]
         """
-        response = self.eval_js(f'window.localStorage.setItem("{key}", "{value}")')
+        response = self.eval_js(f"window.localStorage.setItem({key!r}, {value!r})")
         logger.info(response.log)
 
     @keyword(name="localStorage remove Item", tags=("Setter", "PageContent"))
@@ -146,7 +146,7 @@ class WebAppState(LibraryComponent):
 
         [https://forum.robotframework.org/t//4324|Comment >>]
         """
-        response = self.eval_js(f'window.sessionStorage.getItem("{key}")')
+        response = self.eval_js(f"window.sessionStorage.getItem({key!r})")
         logger.info(response.log)
         formatter = self.keyword_formatters.get(self.session_storage_get_item)
         return verify_assertion(
@@ -170,7 +170,7 @@ class WebAppState(LibraryComponent):
 
         [https://forum.robotframework.org/t//4326|Comment >>]
         """
-        response = self.eval_js(f'window.sessionStorage.setItem("{key}", "{value}")')
+        response = self.eval_js(f"window.sessionStorage.setItem({key!r}, {value!r})")
         logger.info(response.log)
 
     @keyword(name="sessionStorage remove Item", tags=("Setter", "PageContent"))
@@ -188,7 +188,7 @@ class WebAppState(LibraryComponent):
 
         [https://forum.robotframework.org/t//4325|Comment >>]
         """
-        response = self.eval_js(f'window.sessionStorage.removeItem("{key}")')
+        response = self.eval_js(f"window.sessionStorage.removeItem({key!r})")
         logger.info(response.log)
 
     @keyword(name="sessionStorage clear", tags=("Setter", "PageContent"))

--- a/Browser/utils/__init__.py
+++ b/Browser/utils/__init__.py
@@ -52,3 +52,4 @@ from .misc import (
 )
 from .robot_booleans import is_falsy, is_truthy
 from .settings_stack import ScopedSetting, SettingsStack
+from robot.utils import DotDict

--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -285,7 +285,7 @@ class RecordVideo(TypedDict, total=False):
 
     Examples:
     |  New Context  recordVideo={'dir':'videos', 'size':{'width':400, 'height':200}}
-    |  New Context  recordVideo={'dir': '${OUTPUT_DIR}/video'}
+    |  New Context  recordVideo={'dir': 'd:/automation/video'}
     """
 
     dir: str
@@ -485,6 +485,18 @@ class CookieType(Enum):
 CookieSameSite = Enum(
     "CookieSameSite", {"Strict": "Strict", "Lax": "Lax", "None": "None"}
 )
+CookieSameSite.__doc__ = """Enum that defines the Cookie SameSite type.
+
+It controls whether or not a cookie is sent with cross-site requests, providing some protection against cross-site request forgery attacks (CSRF).
+
+The possible attribute values are:
+| = Value = | = Description = |
+| ``Strict`` | Means that the browser sends the cookie only for same-site requests, that is, requests originating from the same site that set the cookie. If a request originates from a different domain or scheme (even with the same domain), no cookies with the SameSite=Strict attribute are sent. |
+| ``Lax`` | Means that the cookie is not sent on cross-site requests, such as on requests to load images or frames, but is sent when a user is navigating to the origin site from an external site (for example, when following a link). This is the default behavior if the SameSite attribute is not specified. |
+| ``None`` | means that the browser sends the cookie with both cross-site and same-site requests. The Secure attribute must also be set when setting this value. |
+
+See [https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie|MDN Set-Cookie] for more information.
+"""
 
 
 class RequestMethod(Enum):

--- a/atest/test/03_Waiting/wait_for_http.robot
+++ b/atest/test/03_Waiting/wait_for_http.robot
@@ -28,7 +28,7 @@ Wait For Request Url
 
 Wait For Request Regex
     Click    \#delayed_request
-    Wait For Request    matcher=\\/\\/local\\w+\\:\\d+\\/api    timeout=1s
+    Wait For Request    matcher=/\\/\\/local\\w+\\:\\d+\\/api/    timeout=1s
 
 Wait For Request Predicate
     Click    \#delayed_request
@@ -45,7 +45,7 @@ Wait For Response Synchronous With Default Timeout
 
 Wait For Response Synchronous With Regex Matcher
     Click    \#delayed_request
-    Wait For Response    matcher=\\/\\/local\\w+\\:\\d+\\/api
+    Wait For Response    matcher=/\\/\\/local\\w+\\:\\d+\\/api/
 
 Wait For Response Synchronous With Predicate
     Click    \#delayed_request

--- a/atest/test/05_JS_Tests/http_with_waiting.robot
+++ b/atest/test/05_JS_Tests/http_with_waiting.robot
@@ -5,7 +5,7 @@ Suite Setup     New Page    ${LOGIN_URL}
 
 *** Test Cases ***
 GET With Waiting Json Response
-    ${promise} =    Promise To    Wait For Response    matcher=/api/get/json    timeout=3s
+    ${promise} =    Promise To    Wait For Response    matcher=**/api/get/json    timeout=3s
     &{response} =    HTTP    /api/get/json
     ${content} =    Wait For    ${promise}
     Should Contain    ${content}[headers][content-type]    application/json
@@ -14,9 +14,13 @@ GET With Waiting Json Response
     Should Be Equal    ${content}[request][method]    GET
 
 POST With Waiting Json Response
-    ${promise} =    Promise To    Wait For Response    matcher=/api/post    timeout=3s
+    ${promise} =    Promise To
+    ...    Wait For Response
+    ...    matcher= response => response.url() === '${ROOT_URL}api/post' && response.status() === 200
+    ...    timeout=3s
     &{response} =    HTTP    /api/post    POST    {"name": "George"}
     ${content} =    Wait For    ${promise}
+    Log To Console    ${{json.dumps($content, indent=4)}}
     Should Contain    ${content}[headers][content-type]    application/json
     Should Contain    ${response}[headers][content-type]    application/json
     Should Be Matching    ${content}    ${response}
@@ -24,7 +28,7 @@ POST With Waiting Json Response
     Should Be Equal    ${content}[request][postData][name]    George
 
 GET With Text Response
-    ${promise} =    Promise To    Wait For Response    matcher=/api/get/text    timeout=3s
+    ${promise} =    Promise To    Wait For Response    matcher=/http://\\w+:\\d+/api/get/text/i    timeout=3s
     &{response} =    HTTP    /api/get/text
     ${content} =    Wait For    ${promise}
     Should Contain    ${content}[headers][content-type]    text/html
@@ -33,7 +37,7 @@ GET With Text Response
     Should Be Equal    ${content}[request][method]    GET
 
 GET With Binary Response
-    ${promise} =    Promise To    Wait For Response    matcher=/api/get/bad_binary    timeout=3s
+    ${promise} =    Promise To    Wait For Response    matcher=${ROOT_URL}api/get/bad_binary    timeout=3s
     &{response} =    HTTP    /api/get/bad_binary
     ${content} =    Wait For    ${promise}
     Should Be Matching    ${content}    ${response}

--- a/node/playwright-wrapper/evaluation.ts
+++ b/node/playwright-wrapper/evaluation.ts
@@ -72,20 +72,6 @@ export async function getElements(request: Request.ElementSelector, state: Playw
     return jsonResponse(JSON.stringify(allSelectors), `Found ${allLocators} Locators successfully.`);
 }
 
-function parseRegExpOrKeepString(str: string): RegExp | string {
-    const regex = /^\/(?<matcher>.*)\/(?<flags>[gimsuy]+)?$/;
-    const match = str.match(regex);
-    if (match) {
-        try {
-            const { matcher, flags } = match.groups!;
-            return new RegExp(matcher, flags);
-        } catch (e) {
-            return str;
-        }
-    }
-    return str;
-}
-
 type AriaRole =
     | 'alert'
     | 'alertdialog'

--- a/node/playwright-wrapper/evaluation.ts
+++ b/node/playwright-wrapper/evaluation.ts
@@ -17,7 +17,14 @@ import { Frame, Locator, Page } from 'playwright';
 
 import { PlaywrightState } from './playwright-state';
 import { Request, Response } from './generated/playwright_pb';
-import { emptyWithLog, intResponse, jsResponse, jsonResponse, stringResponse } from './response-util';
+import {
+    emptyWithLog,
+    intResponse,
+    jsResponse,
+    jsonResponse,
+    parseRegExpOrKeepString,
+    stringResponse,
+} from './response-util';
 import { exists, findLocator } from './playwright-invoke';
 
 import { pino } from 'pino';

--- a/node/playwright-wrapper/response-util.ts
+++ b/node/playwright-wrapper/response-util.ts
@@ -123,3 +123,17 @@ export function keywordsResponse(
     response.setLog(logMessage);
     return response;
 }
+
+export function parseRegExpOrKeepString(str: string): RegExp | string {
+    const regex = /^\/(?<matcher>.*)\/(?<flags>[gimsuy]+)?$/;
+    try {
+        const match = str.match(regex);
+        if (match) {
+            const { matcher, flags } = match.groups!;
+            return new RegExp(matcher, flags);
+        }
+        return str;
+    } catch (e) {
+        return str;
+    }
+}


### PR DESCRIPTION
This is a backwards Incompatible change. Because `Wait For Request` and `Wait For Response` did always create a RegExp object in JS there was no / needed. But because of that, no full text match was possible and no strings were possible.

This will be fixed with this keyword, so that it works same as others that may accept regular expressions.