### PR TITLE
Added `disable_playwright_log` argument to Browser `__init__`

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -743,6 +743,7 @@ class Browser(DynamicCore):
         auto_closing_level: AutoClosingLevel = AutoClosingLevel.TEST,
         enable_playwright_debug: bool = False,
         enable_presenter_mode: Union[HighLightElement, bool] = False,
+        disable_playwright_log: bool = False,
         external_browser_executable: Optional[Dict[SupportedBrowsers, str]] = None,
         jsextension: Union[List[str], str, None] = None,
         playwright_process_port: Optional[int] = None,
@@ -794,7 +795,7 @@ class Browser(DynamicCore):
             Waiter(self),
             WebAppState(self),
         ]
-        self._playwright_log = Path(self.outputdir, "playwright-log.txt")
+        self._playwright_log = None if disable_playwright_log else Path(self.outputdir, "playwright-log.txt")
         self.playwright = Playwright(
             self,
             enable_playwright_debug,

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -741,9 +741,9 @@ class Browser(DynamicCore):
         self,
         *_,
         auto_closing_level: AutoClosingLevel = AutoClosingLevel.TEST,
+        disable_playwright_log: bool = False,
         enable_playwright_debug: bool = False,
         enable_presenter_mode: Union[HighLightElement, bool] = False,
-        disable_playwright_log: bool = False,
         external_browser_executable: Optional[Dict[SupportedBrowsers, str]] = None,
         jsextension: Union[List[str], str, None] = None,
         playwright_process_port: Optional[int] = None,
@@ -759,6 +759,7 @@ class Browser(DynamicCore):
 
         | =Argument=                        | =Description= |
         | ``auto_closing_level``            | Configure context and page automatic closing. Default is ``TEST``, for more details, see `AutoClosingLevel` |
+        | ``disable_playwright_log``        | Disable the creation of the playwright-log.txt file. |
         | ``enable_playwright_debug``       | Enable low level debug information from the playwright to playwright-log.txt file. Mainly Useful for the library developers and for debugging purposes. Will og everything as plain text, also including secrects. |
         | ``enable_presenter_mode``         | Automatic highlights to interacted components, slowMo and a small pause at the end. Can be enabled by giving True or can be customized by giving a dictionary: `{"duration": "2 seconds", "width": "2px", "style": "dotted", "color": "blue"}` Where `duration` is time format in Robot Framework format, defaults to 2 seconds. `width` is width of the marker in pixels, defaults the `2px`. `style` is the style of border, defaults to `dotted`. `color` is the color of the marker, defaults to `blue`. |
         | ``external_browser_executable``   | Dict mapping name of browser to path of executable of a browser. Will make opening new browsers of the given type use the set executablePath. Currently only configuring of `chromium` to a separate executable (chrome, chromium and Edge executables all work with recent versions) works. |

--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -44,7 +44,7 @@ class Playwright(LibraryComponent):
         library: "Browser",
         enable_playwright_debug: bool,
         port: Optional[int] = None,
-        playwright_log: Path = Path(Path.cwd()),
+        playwright_log: Optional[Path] = Path.cwd() / "playwright.log",
     ):
         LibraryComponent.__init__(self, library)
         self.enable_playwright_debug = enable_playwright_debug
@@ -94,7 +94,10 @@ class Playwright(LibraryComponent):
         current_dir = Path(__file__).parent
         workdir = current_dir / "wrapper"
         playwright_script = workdir / "index.js"
-        logfile = self.playwright_log.open("w")
+        try:
+            logfile = self.playwright_log.open("w") if self.playwright_log is not None else DEVNULL
+        except Exception as err:
+            logfile = DEVNULL
         port = str(find_free_port())
         if self.enable_playwright_debug:
             os.environ["DEBUG"] = "pw:api"


### PR DESCRIPTION
Sometimes the playwright log causes issues.
With this new argument user may disable logging of playwright.