### PR TITLE
added defaultBrowser and removed non functional args

### DIFF
--- a/Browser/keywords/browser_control.py
+++ b/Browser/keywords/browser_control.py
@@ -127,14 +127,14 @@ class Control(LibraryComponent):
         | ``selector`` | Take a screenshot of the element matched by selector. See the `Finding elements` section for details about the selectors. If not provided take a screenshot of current viewport. |
         | ``crop`` | Crops the taken screenshot to the given box. It takes same dictionary as returned from `Get BoundingBox`. Cropping only works on page screenshot, so if no selector is given. |
         | ``disableAnimations`` | When set to ``True``, stops CSS animations, CSS transitions and Web Animations. Animations get different treatment depending on their duration:  - finite animations are fast-forwarded to completion, so they'll fire transitionend event.  - infinite animations are canceled to initial state, and then played over after the screenshot. |
-        | ``fileType`` | <"png"|"jpeg"> Specify screenshot type, defaults to png. |
+        | ``fileType`` | ``png`` or ``jpeg`` Specify screenshot type, defaults to ``png`` . |
         | ``fullPage`` | When True, takes a screenshot of the full scrollable page, instead of the currently visible viewport. Defaults to False. |
         | ``log_screenshot`` | When set to ``False`` the screenshot is taken but not logged into log.html. |
         | ``mask`` | Specify selectors that should be masked when the screenshot is taken. Masked elements will be overlayed with a pink box ``#FF00FF`` that completely covers its bounding box. Argument can take a single selector string or a list of selector strings if multiple different elements should be masked. |
         | ``maskColor`` | Specify the color of the overlay box for masked elements, in CSS color format. Default color is pink #FF00FF. |
         | ``omitBackground`` | Hides default white background and allows capturing screenshots with transparency. Not applicable to jpeg images. |
         | ``quality`` | The quality of the image, between 0-100. Not applicable to png images. |
-        | ``scale`` | <css|device>. css will reduce the image size and device keeps image in original size. Defaults to "device".|
+        | ``scale`` | ``css`` or ``device``. ``css`` will reduce the image size and ``device`` keeps image in original size. Defaults to ``device``. |
         | ``return_as`` | Defines what this keyword returns. Possible values are documented in `ScreenshotReturnType`. It can be either a path to the screenshot file as string or Path object, or the image data as bytes or base64 encoded string. |
         | ``timeout`` | Maximum time how long taking screenshot can last, defaults to library timeout. Supports Robot Framework time format, like 10s or 1 min, pass 0 to disable timeout. The default value can be changed by using the `Set Browser Timeout` keyword. |
 

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -333,7 +333,7 @@ class PlaywrightState(LibraryComponent):
         handleSIGHUP: bool = True,
         handleSIGINT: bool = True,
         handleSIGTERM: bool = True,
-        ignoreDefaultArgs: Union[List[str], bool, None] = False,
+        ignoreDefaultArgs: Union[List[str], bool, None] = None,
         proxy: Optional[Proxy] = None,
         reuse_existing: bool = True,
         slowMo: timedelta = timedelta(seconds=0),
@@ -546,7 +546,7 @@ class PlaywrightState(LibraryComponent):
         hasTouch: Optional[bool] = None,
         hideRfBrowser: Deprecated = deprecated,
         httpCredentials: Optional[HttpCredentials] = None,
-        ignoreDefaultArgs: Optional[List[str]] = None,
+        ignoreDefaultArgs: Union[List[str], bool, None] = None,
         ignoreHTTPSErrors: bool = False,
         isMobile: Optional[bool] = None,
         javaScriptEnabled: bool = True,
@@ -562,7 +562,7 @@ class PlaywrightState(LibraryComponent):
             ServiceWorkersPermissions
         ] = ServiceWorkersPermissions.allow,
         slowMo: timedelta = timedelta(seconds=0),
-        storageState: Optional[str] = None,
+        storageState: Deprecated = deprecated,
         timeout: timedelta = timedelta(seconds=30),
         timezoneId: Optional[str] = None,
         tracing: Optional[str] = None,
@@ -583,6 +583,7 @@ class PlaywrightState(LibraryComponent):
         | ``userDataDir``          | Path to a User Data Directory, which stores browser session data like cookies and local storage. More details for Chromium and Firefox. Note that Chromium's user data directory is the parent directory of the "Profile Path" seen at chrome://version. Pass an empty string to use a temporary directory instead. |
         | ``browser``              | Browser type to use. Default is Chromium. |
         | ``headless``             | Whether to run browser in headless mode. Defaults to ``True``. |
+        | ``storageState`` & ``hideRfBrowser`` | These arguments have no function and will be removed soon. |
         | other arguments          | Please see `New Browser`, `New Context` and `New Page` for more information about the other arguments. |
 
         If you want to use extensions you need to download the extension as a .zip, enable loading the extension, and load the extensions using chromium arguments like below. Extensions only work with chromium and with a headful browser.
@@ -595,10 +596,12 @@ class PlaywrightState(LibraryComponent):
         [https://forum.robotframework.org/t//4309|Comment >>]
         """
         params = locals_to_params(locals())
+        params.pop("storageState")  # TODO: remove when arguments are removed.
+        params.pop("hideRfBrowser")
         params["viewport"] = copy(viewport)
         trace_file = Path(self.outputdir, tracing).resolve() if tracing else ""
         params = self._set_browser_options(params, browser, channel, slowMo, timeout)
-        params = self._set_context_options(params, httpCredentials, storageState)
+        params = self._set_context_options(params, httpCredentials, None)
         options = json.dumps(params, default=str)
 
         with self.playwright.grpc_channel() as stub:

--- a/node/playwright-wrapper/playwright-state.ts
+++ b/node/playwright-wrapper/playwright-state.ts
@@ -606,7 +606,7 @@ export async function newPersistentContext(
 
     const userDataDir = options?.userDataDir as string;
     let browser: BrowserType;
-    switch (options.browser) {
+    switch (options.defaultBrowserType || options.browser) {
         case 'chromium':
             browser = chromium;
             break;


### PR DESCRIPTION
This fixes some issues with `New Persistent Context`

Arguments:
- `defaultBrowserType` has not been handled in the past. so handing over devices had no influence on the browser.
- `storageState` does not work for persistent context in Playwright. Therefore it will be removed.