### PR TITLE
Switching Browser, Context and Pages brings page to front

### DIFF
--- a/Browser/keywords/webapp_state.py
+++ b/Browser/keywords/webapp_state.py
@@ -53,7 +53,7 @@ class WebAppState(LibraryComponent):
         | ``assertion_operator`` | Assertion operator to use. See `Assertions` for more information. |
         | ``assertion_expected`` | Expected value to compare with. |
         | ``message`` | Custom error message to use. |
-        | ``frame_selector`` | If this selector points to an element inside an iframe, the LocalStorage of that frame is used. Example: `iframe[name="test"] >>> body` |
+        | ``frame_selector`` | If this selector points to an element inside an iframe, the LocalStorage of that frame is used. Example: ``iframe[name="test"] >>> body`` |
 
 
         See `Assertions` for further details for the assertion arguments. Defaults to None.
@@ -85,7 +85,7 @@ class WebAppState(LibraryComponent):
         | =Arguments= | =Description= |
         | ``key`` | The name of the key under which it should be saved. |
         | ``value`` | The value which shall be saved as a string. |
-        | ``frame_selector`` | If this selector points to an element inside an iframe, the LocalStorage of that frame is used. Example: `iframe[name="test"] >>> body` |
+        | ``frame_selector`` | If this selector points to an element inside an iframe, the LocalStorage of that frame is used. Example: ``iframe[name="test"] >>> body`` |
 
 
         Example:
@@ -104,7 +104,7 @@ class WebAppState(LibraryComponent):
 
         | =Arguments= | =Description= |
         | ``key`` | The name of the item which shall be deleted. |
-        | ``frame_selector`` | If this selector points to an element inside an iframe, the LocalStorage of that frame is used. Example: `iframe[name="test"] >>> body` |
+        | ``frame_selector`` | If this selector points to an element inside an iframe, the LocalStorage of that frame is used. Example: ``iframe[name="test"] >>> body`` |
 
         Example:
         | `Local Storage Set Item`      Foo    bar
@@ -124,7 +124,7 @@ class WebAppState(LibraryComponent):
         """Remove all saved data from the local storage.
 
         | =Arguments= | =Description= |
-        | ``frame_selector`` | If this selector points to an element inside an iframe, the LocalStorage of that frame is used. Example: `iframe[name="test"] >>> body` |
+        | ``frame_selector`` | If this selector points to an element inside an iframe, the LocalStorage of that frame is used. Example: ``iframe[name="test"] >>> body`` |
 
         Example:
         | `Local Storage Set Item`      Foo    bar
@@ -156,7 +156,7 @@ class WebAppState(LibraryComponent):
         | ``assertion_operator`` | Assertion operator to use. See `Assertions` for more information. |
         | ``assertion_expected`` | Expected value to compare with. |
         | ``message`` | Custom error message to use. |
-        | ``frame_selector`` | If this selector points to an element inside an iframe, the SessionStorage of that frame is used. Example: `iframe[name="test"] >>> body` |
+        | ``frame_selector`` | If this selector points to an element inside an iframe, the SessionStorage of that frame is used. Example: ``iframe[name="test"] >>> body`` |
 
         Example:
         | `SessionStorage Set Item`    key2    value2
@@ -188,7 +188,7 @@ class WebAppState(LibraryComponent):
         | =Arguments= | =Description= |
         | ``key`` | The name of the key under which it should be saved. |
         | ``value`` | The value which shall be saved as a string. |
-        | ``frame_selector`` | If this selector points to an element inside an iframe, the SessionStorage of that frame is used. Example: `iframe[name="test"] >>> body` |
+        | ``frame_selector`` | If this selector points to an element inside an iframe, the SessionStorage of that frame is used. Example: ``iframe[name="test"] >>> body`` |
 
         Example:
         | `SessionStorage Set Item`    key2    value2
@@ -209,7 +209,7 @@ class WebAppState(LibraryComponent):
 
         | =Arguments= | =Description= |
         | ``key`` | The name of the item which shall be deleted. |
-        | ``frame_selector`` | If this selector points to an element inside an iframe, the SessionStorage of that frame is used. Example: `iframe[name="test"] >>> body` |
+        | ``frame_selector`` | If this selector points to an element inside an iframe, the SessionStorage of that frame is used. Example: ``iframe[name="test"] >>> body`` |
 
         Example:
         | `SessionStorage Set Item`       mykey2    myvalue2
@@ -228,7 +228,7 @@ class WebAppState(LibraryComponent):
         """Remove all saved data from the session storage.
 
         | =Arguments= | =Description= |
-        | ``frame_selector`` | If this selector points to an element inside an iframe, the SessionStorage of that frame is used. Example: `iframe[name="test"] >>> body` |
+        | ``frame_selector`` | If this selector points to an element inside an iframe, the SessionStorage of that frame is used. Example: ``iframe[name="test"] >>> body`` |
 
         Example:
         | `SessionStorage Set Item`    mykey3    myvalue3


### PR DESCRIPTION
Pages were always brought to front when `Switch Page` or `Switch Context` actually switches anything.
That did not happen with `Switch Browser`

Also if `Switch Page    CURRENT` were called the current page was nit brought to front.

This is fixed now. Every Switch does also brings the current page to front.