### PR TITLE
Add changes from @wvanasten

### DIFF
--- a/node/playwright-wrapper/network.ts
+++ b/node/playwright-wrapper/network.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as path from 'path';
 import * as pb from './generated/playwright_pb';
 import { Page } from 'playwright';
 
@@ -117,14 +118,17 @@ export async function waitForDownload(request: pb.Request.FilePath, page: Page):
     const saveAs = request.getPath();
     const downloadObject = await page.waitForEvent('download');
 
+    let filePath;
     if (saveAs) {
         await downloadObject.saveAs(saveAs);
+        filePath = path.resolve(saveAs);
+    } else {
+        filePath = await downloadObject.path();
     }
-    const path = await downloadObject.path();
     const fileName = downloadObject.suggestedFilename();
-    logger.info('suggestedFilename: ' + fileName + ' saveAs path: ' + path);
+    logger.info('suggestedFilename: ' + fileName + ' saveAs path: ' + filePath);
     return jsonResponse(
-        JSON.stringify({ saveAs: path, suggestedFilename: fileName }),
-        'Download done successfully to: ' + path,
+        JSON.stringify({ saveAs: filePath, suggestedFilename: fileName }),
+        'Download done successfully to: ' + filePath,
     );
 }


### PR DESCRIPTION
Just to be perfectly clear, the code changes originate from @wvanasten from link below, I just implemented them on browser-library main branch and ran acceptance tests on them to make sure the changes don't introduce unexpected issues, not trying to take credit for the actual IP
https://github.com/wvanasten/robotframework-browser/tree/remote-download-save-as

Edit: 
This whole PR stems from issue #2615
https://github.com/MarketSquare/robotframework-browser/issues/2615

As mentioned in my comment in the link above, the changes don't introduce issues in any connected area and I tested the solution itself and found it to be working well when provided an absolute path to the desired saveAs directory