### PR TITLE
Inproves the playwright-log.txt handling

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -1351,7 +1351,16 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
         log_file = Path(self.outputdir, "playwright-log.txt")
         if not log_file.is_file():
             return log_file
+        if self._unlink(log_file):
+            return log_file
         name = log_file.name
         file_name, ext = name.split(".")
         name = f"{file_name}-{time.time_ns()}.{ext}"
         return Path(self.outputdir, name)
+
+    def _unlink(self, file: Path):  # to ease unit testing
+        try:
+            file.unlink(missing_ok=True)
+        except Exception:
+            return False
+        return True

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -816,7 +816,7 @@ class Browser(DynamicCore):
         if enable_playwright_debug == PlaywrightLogTypes.disabled:
             self._playwright_log = None
         else:
-            self._playwright_log = Path(self.outputdir, "playwright-log.txt")
+            self._playwright_log = self._get_log_file_name()
         self.playwright = Playwright(
             self,
             enable_playwright_debug,
@@ -1346,3 +1346,12 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
 
     def _get_assertion_formatter(self, keyword: str) -> list:
         return self._assertion_formatter.get_formatter(keyword)
+
+    def _get_log_file_name(self) -> Path:
+        log_file = Path(self.outputdir, "playwright-log.txt")
+        if not log_file.is_file():
+            return log_file
+        name = log_file.name
+        file_name, ext = name.split(".")
+        name = f"{file_name}-{time.time_ns()}.{ext}"
+        return Path(self.outputdir, name)

--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -59,9 +59,7 @@ class Playwright(LibraryComponent):
         atexit.register(self.close)
         self.wait_until_server_up()
         if platform.system() == "Darwin":
-            time.sleep(
-                1
-            )  # To overcome problem with macOS Sonoma problem and hanging process
+            time.sleep(1)  # To overcome problem with macOS Sonoma and hanging process
         return process
 
     def ensure_node_dependencies(self):

--- a/Browser/utils/__init__.py
+++ b/Browser/utils/__init__.py
@@ -32,6 +32,7 @@ from .data_types import (
     LambdaFunction,
     NewPageDetails,
     Permission,
+    PlaywrightLogTypes,
     Proxy,
     RecordHar,
     RecordVideo,

--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -1001,7 +1001,7 @@ class PlaywrightLogTypes(Enum):
     ``library``: Default, only logging from Browser library node side is written to the playwright-log.txt file.
     ``playwright``: Also includes Playwright log messages to the playwright-log.txt file.
     ``false``: Same as `library` and for backwards compatability.
-    ``true``: Same as `playwright` and for backwards compatability.
+    ``true``: Same as `playwright` and for backwards compatibility.
     """
 
     disabled = auto()

--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -988,3 +988,23 @@ class ServiceWorkersPermissions(Enum):
 
     allow = auto()
     block = auto()
+
+
+class PlaywrightLogTypes(Enum):
+    """Enable low level debug information from the playwright to playwright-log.txt file.
+
+    It is possible to disable the creation of playwright-log.txt totally. Mainly useful for the library developers
+    and for debugging purposes. Will log everything as plain text, also including secrets.
+
+    ``disabled``: playwright-log.txt is not created at all. All node side logging is lost.
+    ``library``: Default, only logging from Browser library node side is written to the playwright-log.txt file.
+    ``playwright``: Also includes Playwright log messages to the playwright-log.txt file.
+    ``false``: Same as `library` and for backwards compatability.
+    ``true``: Same as `playwright` and for backwards compatability.
+    """
+
+    disabled = auto()
+    library = auto()
+    playwright = auto()
+    false = library
+    true = playwright

--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -994,7 +994,8 @@ class PlaywrightLogTypes(Enum):
     """Enable low level debug information from the playwright to playwright-log.txt file.
 
     It is possible to disable the creation of playwright-log.txt totally. Mainly useful for the library developers
-    and for debugging purposes. Will log everything as plain text, also including secrets.
+    and for debugging purposes. Will log everything as plain text, also including secrets. If playwright-log.txt file
+    can not be deleted, time.time_ns() is added at the end of file name. Example playwright-log-12345.txt
 
     ``disabled``: playwright-log.txt is not created at all. All node side logging is lost.
     ``library``: Default, only logging from Browser library node side is written to the playwright-log.txt file.

--- a/utest/test_cookie.py
+++ b/utest/test_cookie.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime, timezone
 
 import pytest

--- a/utest/test_python_usage.py
+++ b/utest/test_python_usage.py
@@ -8,6 +8,7 @@ import logging
 
 import Browser
 from Browser import SupportedBrowsers
+from Browser.utils import PlaywrightLogTypes
 
 
 @pytest.fixture()
@@ -22,6 +23,13 @@ def application_server():
 @pytest.fixture()
 def browser():
     browser = Browser.Browser()
+    yield browser
+    browser.close_browser("ALL")
+
+
+@pytest.fixture()
+def browser_no_log():
+    browser = Browser.Browser(enable_playwright_debug=PlaywrightLogTypes.disabled)
     yield browser
     browser.close_browser("ALL")
 
@@ -44,6 +52,22 @@ def test_open_page_get_text(application_server, browser):
 def test_readme_example(browser):
     browser.new_page("https://playwright.dev")
     assert "Playwright" in browser.get_text("h1")
+
+
+def test_playwright_log(browser: Browser.Browser, application_server):
+    root_folder = Path(".").parent
+    log_file = root_folder / "playwright-log.txt"
+    log_file.unlink()
+    browser.new_page("localhost:7272/dist/")
+    assert log_file.is_file()
+
+
+def test_playwright_log_disabled(browser_no_log: Browser.Browser, application_server):
+    root_folder = Path(".").parent
+    log_file = root_folder / "playwright-log.txt"
+    log_file.unlink()
+    browser_no_log.new_page("localhost:7272/dist/")
+    assert not log_file.is_file()
 
 
 def test_new_browser_and_close(browser):


### PR DESCRIPTION
Not it is possible to prevent creation of playwright-log.txt. If playwright-log.txt exist, then epoch timestamp is added to the filename. Instead of playwright-log.txt use playwright-log-1234.txt 

Fixes #2968