### PR TITLE
added keywords and entry to launch browser server

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -789,7 +789,7 @@ class Browser(DynamicCore):
         self.scope_stack: Dict = {}
         self.suite_ids: Dict[str, None] = {}
         self.current_test_id: Optional[str] = None
-        self._playwright_state = PlaywrightState(self)
+        self._playwright_state: PlaywrightState = PlaywrightState(self)
         self._browser_control = Control(self)
         self._assertion_formatter = Formatter(self)
         libraries = [

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -324,24 +324,34 @@ class PlaywrightState(LibraryComponent):
         self,
         wsEndpoint: str,
         browser: SupportedBrowsers = SupportedBrowsers.chromium,
+        use_cdp: bool = False,
     ):
-        """Connect to a Playwright browser server via websocket.
+        """Connect to a Playwright browser server via playwright websocket or Chrome DevTools Protocol.
 
-        See `Launch Browser Server` for more information about how to launch a browser server.
+        See `Launch Browser Server` for more information about how to launch a playwright browser server.
 
         See `Browser, Context and Page` for more information about Browser and related concepts.
 
         Returns a stable identifier for the connected browser.
 
         | =Argument=     | =Description= |
-        | ``wsEndpoint`` | Address to connect to. |
+        | ``wsEndpoint`` | Address to connect to. Either ``ws://`` or ``http://`` if cdp is used. |
         | ``browser``    | Opens the specified browser. Defaults to ``chromium``. |
+        | ``use_cdp``    | Connect to browser via Chrome DevTools Protocol. Defaults to False. Works only with Chromium based browsers. |
+
+        To Connect to a Browser viw Chrome DevTools Protocol, the browser must be started with this protocol enabled.
+        This typically done by starting a Chrome browser with the argument ``--remote-debugging-port=9222`` or similar.
+        When the browser is running with activated CDP, it is possible to connect to it either with websockets (``ws://``)
+        or via HTTP (``http://``). The HTTP connection can be used when ``use_cdp`` is set to True.
+        A typical address for a CDP connection is ``http://127.0.0.1:9222``.
 
         [https://forum.robotframework.org/t//4242|Comment >>]
         """
         with self.playwright.grpc_channel() as stub:
             response = stub.ConnectToBrowser(
-                Request().ConnectBrowser(url=wsEndpoint, browser=browser.name)
+                Request().ConnectBrowser(
+                    url=wsEndpoint, browser=browser.name, connectCDP=use_cdp
+                )
             )
             logger.info(response.log)
             return response.body

--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -186,6 +186,12 @@ class Playwright(LibraryComponent):
             self._channel.close()
         except Exception as exc:
             logger.debug(f"Failed to close browsers: {exc}")
+        try:
+            with self.grpc_channel() as stub:
+                response = stub.CloseBrowserServer(Request().ConnectBrowser(url="ALL"))
+                logger.info(response.log)
+        except Exception as exc:
+            logger.debug(f"Failed to close browser servers: {exc}")
         # Access (possibly) cached property without actually invoking it
         playwright_process = self.__dict__.get("_playwright_process")
         if playwright_process:

--- a/atest/test/01_Browser_Management/new_page_should_not_timeout.robot
+++ b/atest/test/01_Browser_Management/new_page_should_not_timeout.robot
@@ -10,6 +10,20 @@ New Page Will Not Timeout
     New Page    ${SLOW_PAGE}
     Get Title    ==    Slow page
 
+New Page Will Timeout And Page Will Be Removed From Catalog
+    [Tags]    slow
+    Set Browser Timeout    1s
+    New Context
+    ${Catalog} =    Get Browser Catalog
+    TRY
+        New Page    ${SLOW_PAGE}
+    EXCEPT    *timeout*    type=glob
+        ${new_catalog} =    Get Browser Catalog
+        Should Be Equal    ${Catalog}    ${new_catalog}
+    ELSE
+        Fail    Expected timeout
+    END
+
 *** Keywords ***
 Setup
     Set Browser Timeout    15s    scope=Suite

--- a/atest/test/01_Browser_Management/persistent_state.robot
+++ b/atest/test/01_Browser_Management/persistent_state.robot
@@ -70,3 +70,28 @@ New Persistent Context Open New Pages
     Switch Page    NEW
     Get Url    ==    ${ERROR_URL}
     [Teardown]    Set Retry Assertions For    ${old}
+
+New Persistent Context Cleaned Up After Timeout
+    [Tags]    slow
+    [Setup]    Close Browser    ALL
+    Set Browser Timeout    1s    Test
+    ${catalog_1} =    Get Browser Catalog
+    TRY
+        New Persistent Context    url=${SLOW_PAGE}    timeout=1s
+    EXCEPT    *timeout*    type=GLOB
+        ${catalog_2} =    Get Browser Catalog
+        Should Be Equal    ${catalog_1}    ${catalog_2}
+    END
+    New Browser
+    New Page    url=${ERROR_URL}
+    Get Title    ==    Error Page
+    New Persistent Context    url=${WELCOME_URL}
+    Get Title    ==    Welcome Page
+    ${catalog_3} =    Get Browser Catalog
+    TRY
+        New Persistent Context    url=${SLOW_PAGE}    timeout=1s
+    EXCEPT    *timeout*    type=GLOB
+        ${catalog_4} =    Get Browser Catalog
+        Should Be Equal    ${catalog_3}    ${catalog_4}
+    END
+    Get Title    ==    Welcome Page

--- a/atest/test/01_Browser_Management/persistent_state.robot
+++ b/atest/test/01_Browser_Management/persistent_state.robot
@@ -25,13 +25,15 @@ Switching Between Two Persistent Contexts Works
     ${url_2} =    Get Url
     ${title_2} =    Get Title
 
-    Switch Browser    ${browser_1}
+    Should Be Equal    ${browser_1}    ${browser_2}
+
+    Switch Context    ${context_1}
     Get URL    ==    ${url_1}
     Get Title    ==    ${title_1}
     ${switch_id} =    Switch Context    CURRENT
     Should Be Equal    ${context_1}    ${switch_id}
 
-    Switch Browser    ${browser_2}
+    Switch Context    ${context_2}
     Get URL    ==    ${url_2}
     Get Title    ==    ${title_2}
     ${switch_id} =    Switch Context    CURRENT

--- a/atest/test/01_Browser_Management/playwright_state.robot
+++ b/atest/test/01_Browser_Management/playwright_state.robot
@@ -419,24 +419,29 @@ Launch Browser Server Generated wsEndpoint
 
 Launch Browser Server Via CLI
     ${process1} =    Start Process
-    ...    rfbrowser
+    ...    python
+    ...    -m
+    ...    Browser.entry
     ...    launch-browser-server
     ...    chromium
     ...    headless\=${HEADLESS}
-    ...    port\=8272
+    ...    port\=8277
     ...    wsPath\=server2
     ${process2} =    Start Process
-    ...    rfbrowser
+    ...    python
+    ...    -m
+    ...    Browser.entry
     ...    launch-browser-server
     ...    chromium
     ...    headless\=${HEADLESS}
     ...    port\=8273
     ...    wsPath\=server3
-    Connect To Browser    wsEndpoint=ws://localhost:8272/server2    browser=chromium
+    Sleep    10s
+    Connect To Browser    wsEndpoint=ws://localhost:8277/server2    browser=chromium
     New Page    ${LOGIN_URL}
     Get Title    ==    Login Page
     Close Browser    ALL
-    Connect To Browser    wsEndpoint=ws://localhost:8272/server2    browser=chromium
+    Connect To Browser    wsEndpoint=ws://localhost:8277/server2    browser=chromium
     New Page    ${FORM_URL}
     Get Title    ==    prefilled_email_form.html
     Connect To Browser    wsEndpoint=ws://localhost:8273/server3    browser=chromium

--- a/atest/test/01_Browser_Management/playwright_state.robot
+++ b/atest/test/01_Browser_Management/playwright_state.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource            imports.resource
+Library             Process
 
 Test Teardown       Close Browser    ALL
 
@@ -400,6 +401,50 @@ Switch Page With ALL Browsers Failing
     Run Keyword And Expect Error    EQUALS:ValueError: Malformed page `id`: 1
     ...    Run Keyword And Continue On Failure
     ...    Switch Page    1    ALL    ALL
+
+Launch Browser Server CLI
+    ${wsEndpoint} =    Launch Browser Server    chromium    headless=${HEADLESS}    port=8271    wsPath=server1
+    Should Be Equal    ${wsEndpoint}    ws://localhost:8271/server1
+    ${browser} =    Connect To Browser    ws://localhost:8271/server1
+    New Page    ${LOGIN_URL}
+    Get Title    ==    Login Page
+    [Teardown]    Close Browser Server    ${wsEndpoint}
+
+Launch Browser Server Generated wsEndpoint
+    ${wsEndpoint} =    Launch Browser Server    chromium    headless=${HEADLESS}
+    ${browser} =    Connect To Browser    ${wsEndpoint}
+    New Page    ${LOGIN_URL}
+    Get Title    ==    Login Page
+    [Teardown]    Close Browser Server    ${wsEndpoint}
+
+Launch Browser Server Via CLI
+    ${process1} =    Start Process
+    ...    rfbrowser
+    ...    launch-browser-server
+    ...    chromium
+    ...    headless\=${HEADLESS}
+    ...    port\=8272
+    ...    wsPath\=server2
+    ${process2} =    Start Process
+    ...    rfbrowser
+    ...    launch-browser-server
+    ...    chromium
+    ...    headless\=${HEADLESS}
+    ...    port\=8273
+    ...    wsPath\=server3
+    Connect To Browser    wsEndpoint=ws://localhost:8272/server2    browser=chromium
+    New Page    ${LOGIN_URL}
+    Get Title    ==    Login Page
+    Close Browser    ALL
+    Connect To Browser    wsEndpoint=ws://localhost:8272/server2    browser=chromium
+    New Page    ${FORM_URL}
+    Get Title    ==    prefilled_email_form.html
+    Connect To Browser    wsEndpoint=ws://localhost:8273/server3    browser=chromium
+    New Context    viewport={"width": 100, "height": 100}
+    New Page    ${LOGIN_URL}
+    Get Viewport Size    width    ==    100
+    Get Viewport Size    height    ==    100
+    [Teardown]    Terminate All Processes
 
 *** Keywords ***
 Open Browser And Assert Login Page

--- a/atest/test/01_Browser_Management/playwright_state.robot
+++ b/atest/test/01_Browser_Management/playwright_state.robot
@@ -404,7 +404,7 @@ Switch Page With ALL Browsers Failing
 
 Launch Browser Server CLI
     ${wsEndpoint} =    Launch Browser Server    chromium    headless=${HEADLESS}    port=8271    wsPath=server1
-    Should Be Equal    ${wsEndpoint}    ws://localhost:8271/server1
+    Should Be Equal    ${wsEndpoint}    ws://127.0.0.1:8271/server1
     ${browser} =    Connect To Browser    ws://localhost:8271/server1
     New Page    ${LOGIN_URL}
     Get Title    ==    Login Page

--- a/node/playwright-wrapper/grpc-service.ts
+++ b/node/playwright-wrapper/grpc-service.ts
@@ -146,6 +146,7 @@ export class PlaywrightServer implements IPlaywrightServer {
     }
 
     closeBrowser = this.wrappingState(playwrightState.closeBrowser);
+    closeBrowserServer = this.wrapping(playwrightState.closeBrowserServer);
     closeAllBrowsers = this.wrappingState(playwrightState.closeAllBrowsers);
     closeContext = this.wrappingState(playwrightState.closeContext);
     closePage = this.wrapping(playwrightState.closePage);
@@ -243,6 +244,7 @@ export class PlaywrightServer implements IPlaywrightServer {
     newPage = this.wrapping(playwrightState.newPage);
     newContext = this.wrapping(playwrightState.newContext);
     newBrowser = this.wrapping(playwrightState.newBrowser);
+    launchBrowserServer = this.wrapping(playwrightState.launchBrowserServer);
     newPersistentContext = this.wrapping(playwrightState.newPersistentContext);
     connectToBrowser = this.wrapping(playwrightState.connectToBrowser);
     goTo = this.wrappingPage(browserControl.goTo);

--- a/protobuf/playwright.proto
+++ b/protobuf/playwright.proto
@@ -125,7 +125,8 @@ message Request {
 
   message ConnectBrowser {
     string browser = 1;
-    string url= 2;
+    string url = 2;
+    bool connectCDP = 3;
   }
 
   message TextInput {

--- a/protobuf/playwright.proto
+++ b/protobuf/playwright.proto
@@ -478,6 +478,8 @@ service  Playwright {
   rpc NewPage(Request.UrlOptions) returns (Response.NewPageResponse);
   rpc NewContext(Request.Context) returns (Response.NewContextResponse);
   rpc NewBrowser(Request.Browser) returns (Response.String);
+  rpc LaunchBrowserServer(Request.Browser) returns (Response.String);
+  rpc CloseBrowserServer(Request.ConnectBrowser) returns (Response.Empty);
   rpc NewPersistentContext(Request.PersistentContext) returns (Response.NewPersistentContextResponse);
   rpc ConnectToBrowser(Request.ConnectBrowser) returns (Response.String);
   rpc CloseBrowser(Request.Empty) returns (Response.String);


### PR DESCRIPTION
Three new features:

1. `Launch Browser Server` keyword to start a browser with one robot and connect to it with another.
2. `Close Browser Server` keyword to terminate this browser server.
3. `rfbrowser launch-browser-server` cli entry point to start a server.


example:
`rfbrowser launch-browser-server chromium headless=No port=9999 wsPath=chromium/one`
This will create a server on `ws://localhost:9999/chromium/one`