### PR TITLE
Fix Cookie documentation "expires" instead of "expiry".

### DIFF
--- a/Browser/keywords/cookie.py
+++ b/Browser/keywords/cookie.py
@@ -200,7 +200,7 @@ class Cookie(LibraryComponent):
         | url      | Define the scope of the cookie, what URLs the cookies should be sent to.                   |
         | domain   | Specifies which hosts are allowed to receive the cookie.                                   |
         | path     | Indicates a URL path that must exist in the requested URL, for example `/`.                |
-        | expiry   | Lifetime of a cookie. Returned as datatime object or None if not valid time received.      |
+        | expires  | Lifetime of a cookie. Returned as datatime object or None if not valid time received.      |
         | httpOnly | When true, the cookie is not accessible via JavaScript.                                    |
         | secure   | When true, the cookie is only used with HTTPS connections.                                 |
         | sameSite | Attribute lets servers require that a cookie shouldn't be sent with cross-origin requests. |
@@ -212,7 +212,7 @@ class Cookie(LibraryComponent):
         Example:
         | ${cookie}=        `Get Cookie`              Foobar
         | Should Be Equal   ${cookie.value}           Tidii
-        | Should Be Equal   ${cookie.expiry.year}     ${2020}
+        | Should Be Equal   ${cookie.expires.year}     ${2020}
 
         [https://forum.robotframework.org/t//4265|Comment >>]
         """

--- a/Browser/keywords/cookie.py
+++ b/Browser/keywords/cookie.py
@@ -117,8 +117,8 @@ class Cookie(LibraryComponent):
         Example:
         | `Add Cookie`   foo   bar   http://address.com/path/to/site                                     # Using url argument.
         | `Add Cookie`   foo   bar   domain=example.com                path=/foo/bar                     # Using domain and url arguments.
-        | `Add Cookie`   foo   bar   http://address.com/path/to/site   expiry=2027-09-28 16:21:35        # Expiry as timestamp.
-        | `Add Cookie`   foo   bar   http://address.com/path/to/site   expiry=1822137695                 # Expiry as epoch seconds.
+        | `Add Cookie`   foo   bar   http://address.com/path/to/site   expires=2027-09-28 16:21:35       # Expires as timestamp.
+        | `Add Cookie`   foo   bar   http://address.com/path/to/site   expires=1822137695                # Expires as epoch seconds.
 
         [https://forum.robotframework.org/t//4233|Comment >>]
         """


### PR DESCRIPTION
Fixes #3532 