### PR TITLE
Handle empty response bodies

### DIFF
--- a/Browser/keywords/network.py
+++ b/Browser/keywords/network.py
@@ -49,7 +49,7 @@ def _jsonize_content(data, bodykey):
     if (
         "content-type" in lower_headers
         and "application/json" in lower_headers["content-type"]
-    ):
+    ) and data[bodykey]:
         with contextlib.suppress(json.decoder.JSONDecodeError):
             data[bodykey] = json.loads(data[bodykey])
 

--- a/utest/test_network.py
+++ b/utest/test_network.py
@@ -23,3 +23,10 @@ def test_response_parsing_text():
         }
     )
     assert response["body"] == "{key:'value3'}"
+
+
+def test_empty_response():
+    response = _format_response(
+        {"headers": '{"Content-Type": "application/json"}', "body": None}
+    )
+    assert response["body"] == None


### PR DESCRIPTION
I don't really know why (because I didn't dig that deep), but sometime the response body that hits `_format_response` is `None`. If that happens, the behavior described in #3549 is seen. @nfaustin suggested, to send the body though `json.dumps` (which would convert `None` to `'null'` which is then readable by `json.loads`), but I think simply not transforming the body is a more lightweight solution.

Fixes #3549

Still of course there is the question, why the body is empty in a first place, because neither @nfaustin nor I really expect it to be empty. In my use case, there is an empty response to an OPTION request to the same URL, but I'm matching to the request method GET and am still facing the exception.