### PR TITLE
Shrink docker image a little

### DIFF
--- a/.github/workflows/dockers.yml
+++ b/.github/workflows/dockers.yml
@@ -1,6 +1,7 @@
 name: Docker image and tests
 
 on:
+  push:
   release:
     types: [ published ]
   workflow_dispatch:
@@ -17,6 +18,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
+        if: github.event_name != 'push'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -41,7 +43,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           file: docker/Dockerfile.latest_release
           platforms: linux/arm64/v8,linux/amd64
-          push: true
+          push: ${{ github.event_name != 'push' }}
 
       - name: Docker meta
         id: meta_github
@@ -57,6 +59,7 @@ jobs:
             latest=true
 
       - name: Login to GitHub Container Registry
+        if: github.event_name != 'push'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -69,11 +72,12 @@ jobs:
           platforms: linux/arm64/v8,linux/amd64
           file: docker/Dockerfile.latest_release
           tags: ${{ steps.meta_github.outputs.tags }}
-          push: true
+          push: ${{ github.event_name != 'push' }}
 
   test-docker-image:
     needs: docker-image
     runs-on: ubuntu-latest
+    if: github.event_name != 'push'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.9

--- a/docker/Dockerfile.latest_release
+++ b/docker/Dockerfile.latest_release
@@ -2,8 +2,9 @@ FROM mcr.microsoft.com/playwright:v1.30.0-focal
 
 # Add pip
 USER root
-RUN apt-get update
-RUN apt-get install -y python3 python3-pip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+  apt-get install -y python3 python3-pip && \
+  rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/home/pwuser/.local/bin:${PATH}"
 ENV NODE_PATH=/usr/lib/node_modules
@@ -12,8 +13,7 @@ ENV NODE_PATH=/usr/lib/node_modules
 # RUN chmod a+rwx -R /home/pwuser/.cache
 
 USER pwuser
-RUN pip3 install --no-cache-dir --upgrade pip wheel
-RUN pip3 --version
-RUN pip3 install --no-cache-dir --user --upgrade robotframework robotframework-browser==18.5.1
-
-RUN python3 -m Browser.entry init
+RUN pip3 install --no-cache-dir --upgrade pip wheel && \
+  pip3 --version && \
+  pip3 install --no-cache-dir --user --upgrade robotframework robotframework-browser==18.5.1 && \
+  python3 -m Browser.entry init


### PR DESCRIPTION
improved (fixed) version of #3595
builds but doesn't test because since its a separate step it'd need to push somewhere.

you'd have to either export the docker image to an artifact and pull it in to the second step, or just merge the two things into a single flow

either-way ci it probably needs refactoring to:
build > test > publish

for ci (non release events) it could also probably be optimized for speed to not bother building non-amd64 images since qemu is slow and it needs to compile things