### PR TITLE
feat: only check for node when robot is running

### DIFF
--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -30,6 +30,8 @@ from Browser.generated.playwright_pb2 import Request
 from .base import LibraryComponent
 from .utils import AutoClosingLevel
 
+from robot.libraries.BuiltIn import BuiltIn
+
 if TYPE_CHECKING:
     from .browser import Browser
 
@@ -50,7 +52,8 @@ class Playwright(LibraryComponent):
     ):
         LibraryComponent.__init__(self, library)
         self.enable_playwright_debug = enable_playwright_debug
-        self.ensure_node_dependencies()
+        if BuiltIn().robot_running:
+            self.ensure_node_dependencies()
         self.port = str(port) if port else None
         self.playwright_log = playwright_log
 


### PR DESCRIPTION
Hello,

Sometimes the code completion of IDE fails to import the library due to some issues with the PATH, while when running the test the lib is perfectly imported. This can happen when the IDE does not properly initiate the PATH with node, without impacting the run.
This is why I am suggesting to check if node is installed only if the test is actually running, which would allow IDE to load the keywords even if node is not in PATH

