### PR TITLE
Issue #3286: Handle missing browser options when downloading files

### DIFF
--- a/node/playwright-wrapper/network.ts
+++ b/node/playwright-wrapper/network.ts
@@ -139,7 +139,7 @@ export async function _waitForDownload(
     const downloadObject = await page.waitForEvent('download');
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    const downloadsPath = state.activeBrowser.browser?._options.downloadsPath;
+    const downloadsPath = state.activeBrowser.browser?._options?.downloadsPath;
     if (downloadsPath && saveAs) {
         logger.info('saveAs: ' + path.resolve(downloadsPath, saveAs));
         if (!path.isAbsolute(saveAs)) {


### PR DESCRIPTION
I did not check if this actually solves #3286 but at least it should not make things worse.