### PR TITLE
Playwright is a property now

### DIFF
--- a/atest/test/00_Clean_Output_Dir/01_initial_import.robot
+++ b/atest/test/00_Clean_Output_Dir/01_initial_import.robot
@@ -4,6 +4,13 @@ Library     OperatingSystem
 Resource    ../variables.resource
 
 *** Test Cases ***
+Test Lazy Playwright Loading
+    [Documentation]    Tests that Playwright is not loaded until the first keyword is called
+    ${browser_lib} =    Get Library Instance    Browser
+    Should Be True    $browser_lib._playwright is None
+    ${cat} =    Get Browser Catalog
+    Should Be True    isinstance($browser_lib._playwright, Browser.playwright.Playwright)
+
 Take Screenshot
     New Page    ${TABLES_URL}
     File Should Not Exist    ${OUTPUT DIR}/browser/screenshot/initial_screenshot.png

--- a/atest/test/05_JS_Tests/jsextension.robot
+++ b/atest/test/05_JS_Tests/jsextension.robot
@@ -5,6 +5,11 @@ Resource        imports.resource
 Force Tags      no-iframe
 
 *** Test Cases ***
+Test Lazy Playwright Loading
+    [Documentation]    Tests that Playwright is loaded if jsextension is used
+    ${browser_lib} =    Get Library Instance    Browser
+    Should Be True    isinstance($browser_lib._playwright, Browser.playwright.Playwright)
+
 Promise To Call Custom Js Keyword
     New Page
     ${promise} =    Promise To    My Funky keyword    h1

--- a/utest/test_python_usage.py
+++ b/utest/test_python_usage.py
@@ -8,6 +8,7 @@ import logging
 
 import Browser
 from Browser import SupportedBrowsers
+import Browser.playwright
 from Browser.utils import PlaywrightLogTypes
 
 
@@ -72,6 +73,10 @@ def atexit_register(monkeypatch):
     monkeypatch.setattr(atexit, "register", register)
     return register
 
+def test_playwright_lazy_initialization(browser):
+    assert browser._playwright is None
+    browser.get_browser_catalog()
+    assert isinstance(browser.playwright, Browser.playwright.Playwright)
 
 def test_open_page_get_text(application_server, browser):
     browser.new_page("localhost:7272/dist/")


### PR DESCRIPTION
Browser().playwright is a property now and only initialised if a keyword is called or a JS extension is used.

start_stuite and start_test used it as well, but avoid it if possible.

This fixes issue #3757 and PR #3758