### PR TITLE
Make Playwright host configurable

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -804,6 +804,7 @@ class Browser(DynamicCore):
         external_browser_executable: Optional[dict[SupportedBrowsers, str]] = None,
         jsextension: Union[list[str], str, None] = None,
         language: Optional[str] = None,
+        playwright_process_host: Optional[str] = None,
         playwright_process_port: Optional[int] = None,
         plugins: Union[list[str], str, None] = None,
         retry_assertions_for: timedelta = timedelta(seconds=1),
@@ -824,6 +825,7 @@ class Browser(DynamicCore):
         | ``external_browser_executable``   | Dict mapping name of browser to path of executable of a browser. Will make opening new browsers of the given type use the set executablePath. Currently only configuring of `chromium` to a separate executable (chrome, chromium and Edge executables all work with recent versions) works. |
         | ``jsextension``                   | Path to Javascript modules exposed as extra keywords. The modules must be in CommonJS. It can either be a single path, a comma-separated lists of path or a real list of strings |
         | ``language``                      | Defines language which is used to translate keyword names and documentation. |
+        | ``playwright_process_host``       | Hostname / Host address which should be used when spawning the Playwright process. Defaults to 127.0.0.1. |
         | ``playwright_process_port``       | Experimental reusing of playwright process. ``playwright_process_port`` is preferred over environment variable ``ROBOT_FRAMEWORK_BROWSER_NODE_PORT``. See `Experimental: Re-using same node process` for more details. |
         | ``plugins``                       | Allows extending the Browser library with external Python classes. Can either be a single class/module, a comma-separated list or a real list of strings |
         | ``retry_assertions_for``          | Timeout for retrying assertions on keywords before failing the keywords. This timeout starts counting from the first failure. Global ``timeout`` will still be in effect. This allows stopping execution faster to assertion failure when element is found fast. |
@@ -865,6 +867,7 @@ class Browser(DynamicCore):
             WebAppState(self),
         ]
         self.enable_playwright_debug = enable_playwright_debug
+        self.playwright_process_host = playwright_process_host
         self.playwright_process_port = playwright_process_port
         if self.enable_playwright_debug is True:
             self.enable_playwright_debug = PlaywrightLogTypes.playwright
@@ -937,6 +940,7 @@ class Browser(DynamicCore):
             self._playwright = Playwright(
                 self,
                 self.enable_playwright_debug,
+                self.playwright_process_host,
                 self.playwright_process_port,
                 self._playwright_log,
             )

--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -103,6 +103,8 @@ class Playwright(LibraryComponent):
         existing_port = self.port or env_node_port
         if existing_port is not None:
             self.port = existing_port
+            if self.host is None:
+                self.host = "127.0.0.1"
             if env_node_port is None:
                 logger.trace(
                     f"Using previously saved or imported port {existing_port}, skipping Browser process start"

--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -125,7 +125,9 @@ class Playwright(LibraryComponent):
         port = str(find_free_port())
         if self.enable_playwright_debug == PlaywrightLogTypes.playwright:
             os.environ["DEBUG"] = "pw:api"
-        logger.info(f"Starting Browser process {playwright_script} using at {host}:{port}")
+        logger.info(
+            f"Starting Browser process {playwright_script} using at {host}:{port}"
+        )
         self.host = host
         self.port = port
         node_args = ["node"]

--- a/Browser/utils/misc.py
+++ b/Browser/utils/misc.py
@@ -54,11 +54,13 @@ def spawn_node_process(output_dir: Path) -> tuple[subprocess.Popen, str]:
     logfile = output_dir.open("w", encoding="utf-8")
     os.environ["DEBUG"] = "pw:api"
     os.environ["PLAYWRIGHT_BROWSERS_PATH"] = "0"
+    host = "127.0.0.1"
     port = str(find_free_port())
     process = subprocess.Popen(
         [
             "node",
             "Browser/wrapper/index.js",
+            host,
             port,
         ],
         stdout=logfile,

--- a/node/playwright-wrapper/index.ts
+++ b/node/playwright-wrapper/index.ts
@@ -19,16 +19,26 @@ import { PlaywrightService } from './generated/playwright_grpc_pb';
 import { pino } from 'pino';
 const logger = pino({ timestamp: pino.stdTimeFunctions.isoTime });
 
-const port = process.argv.slice(2);
-if (Object.keys(port).length == 0) {
+const args = process.argv.slice(2);
+
+const host = args[0];
+const port = args[1];
+
+if (!host) {
+    throw new Error(`No host defined`);
+}
+
+if (!port) {
     throw new Error(`No port defined`);
 }
+
 const server = new Server();
 server.addService(
     PlaywrightService as unknown as ServiceDefinition<UntypedServiceImplementation>,
     new PlaywrightServer() as unknown as UntypedServiceImplementation,
 );
-server.bindAsync(`127.0.0.1:${port}`, ServerCredentials.createInsecure(), () => {
-    logger.info(`Listening on ${port}`);
+
+server.bindAsync(`${host}:${port}`, ServerCredentials.createInsecure(), () => {
+    logger.info(`Listening on ${host}:${port}`);
     server.start();
 });


### PR DESCRIPTION
Using robotframework-browser within a VS Code devcontainer on a macOS host with --network host is not possible, since the binding when starting Playwright fails. However, when using 0.0.0.0 as host everything works as expected.

Therefore, this merge request makes the host when starting the playwright process configurable.

Fixes #4012 