### PR TITLE
Fix ruff checks

### DIFF
--- a/Browser/playwright.py
+++ b/Browser/playwright.py
@@ -78,10 +78,14 @@ class Playwright(LibraryComponent):
         installation_dir = rfbrowser_dir / "wrapper"
         # This second application of .parent is necessary to find out that a developer setup has node_modules correctly
         project_folder = rfbrowser_dir.parent
-        subfolders = os.listdir(project_folder) + os.listdir(installation_dir)
-
-        if "node_modules" in subfolders:
+        if any(
+            [
+                (project_folder / "node_modules").is_dir(),
+                (installation_dir / "node_modules").is_dir(),
+            ]
+        ):
             return
+
         raise RuntimeError(
             "\n#############################################################"
             "\n#                                                           #"  # noqa: RUF001

--- a/Browser/utils/js_utilities.py
+++ b/Browser/utils/js_utilities.py
@@ -20,7 +20,7 @@ def get_abs_scroll_coordinates(
     query: Any, scroll_size: int, min_str: str, max_str: str
 ):
     try:
-        return int(round(float(query)))
+        return round(float(query))
     except ValueError:
         pass
     if isinstance(query, str):
@@ -37,7 +37,7 @@ def get_abs_scroll_coordinates(
 
 def get_rel_scroll_coordinates(query: Any, full: int, client: int, dimension_str: str):
     try:
-        return int(round(float(query)))
+        return round(float(query))
     except ValueError:
         pass
     if isinstance(query, str):


### PR DESCRIPTION
 * calling os.listdir() to check if subdirectory exists could be slow
 * round() already returns int if ndigits arg is omitted.