### PR TITLE
Fix for rfbrowser --version command for WIndows

### DIFF
--- a/Browser/entry/get_versions.py
+++ b/Browser/entry/get_versions.py
@@ -32,21 +32,18 @@ def get_pw_version() -> str:
         capture_output=True,
         check=False,
         shell=True,
-        cwd=INSTALLATION_DIR
+        cwd=INSTALLATION_DIR,
     )
     std_out = process.stdout.decode("utf-8")
     match = re.search(r"((?:@[^@]*))$", std_out)
-    
+
     if match:
         version_string = match.group(0)
         version_string = version_string.replace("@", "")
-        version_string = version_string.replace("\r", "")
-        version_string = version_string.replace("\n", "")
-        return version_string
-    else:
-        log(
-            f"Could not get Playwright version, got: {std_out}, reading it from package.json"
-        )
+        return version_string.replace("\r", "").replace("\n", "")
+    log(
+        f"Could not get Playwright version, got: {std_out}, reading it from package.json"
+    )
     package_json = INSTALLATION_DIR / "package.json"
     package_json_data = json.loads(package_json.read_text())
     match = re.search(r"\d+\.\d+\.\d+", package_json_data["dependencies"]["playwright"])

--- a/Browser/entry/get_versions.py
+++ b/Browser/entry/get_versions.py
@@ -31,15 +31,22 @@ def get_pw_version() -> str:
         ["npm", "list", "playwright"],
         capture_output=True,
         check=False,
-        cwd=INSTALLATION_DIR,
+        shell=True,
+        cwd=INSTALLATION_DIR
     )
     std_out = process.stdout.decode("utf-8")
-    match = re.search(r"\@\d+\.\d+\.?\d*$", std_out)
+    match = re.search(r"((?:@[^@]*))$", std_out)
+    
     if match:
-        return match.group(0)
-    log(
-        f"Could not get Playwright version, got: {std_out}, reading it from package.json"
-    )
+        version_string = match.group(0)
+        version_string = version_string.replace("@", "")
+        version_string = version_string.replace("\r", "")
+        version_string = version_string.replace("\n", "")
+        return version_string
+    else:
+        log(
+            f"Could not get Playwright version, got: {std_out}, reading it from package.json"
+        )
     package_json = INSTALLATION_DIR / "package.json"
     package_json_data = json.loads(package_json.read_text())
     match = re.search(r"\d+\.\d+\.\d+", package_json_data["dependencies"]["playwright"])


### PR DESCRIPTION
The `rfbrowser --version` command give an error. Also regex didn't work work when a Playwright version was found through `npm list playwright`. 
**This change is only tested on Windows, since I don't have Linux or a Mac**