### PR TITLE
Sometimes attrs["source"] is None

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -1182,7 +1182,7 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
                 logger.trace(f"Browser._start_test connection problem: {e}")
 
     def _resolve_path(self, attrs: dict) -> Union[Path, None]:
-        source = Path(attrs["source"])
+        source = Path(attrs["source"]) if "source" in attrs and attrs["source"] is not None else None
         if source.is_dir():
             source = source / "__init__.robot"
             if not source.exists():

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -1183,7 +1183,7 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
 
     def _resolve_path(self, attrs: dict) -> Union[Path, None]:
         source = Path(attrs["source"]) if "source" in attrs and attrs["source"] is not None else None
-        if source.is_dir():
+        if source is not None and source.is_dir():
             source = source / "__init__.robot"
             if not source.exists():
                 return None


### PR DESCRIPTION
And this results in an absolute wall of errors in every robot log, e.g.:

```
20250424 14:20:05.655 | ERROR | Calling method '_start_keyword' of listener 'Browser' failed: TypeError: expected str, bytes or os.PathLike object, not NoneType |  
20250424 14:20:05.663 | ERROR | Calling method '_start_keyword' of listener 'Browser' failed: TypeError: expected str, bytes or os.PathLike object, not NoneType |  
20250424 14:20:05.671 | ERROR | Calling method '_start_keyword' of listener 'Browser' failed: TypeError: expected str, bytes or os.PathLike object, not NoneType |  
20250424 14:20:05.673 | ERROR | Calling method '_start_keyword' of listener 'Browser' failed: TypeError: expected str, bytes or os.PathLike object, not NoneType |  
20250424 14:20:05.694 | ERROR | Calling method '_start_keyword' of listener 'Browser' failed: TypeError: expected str, bytes or os.PathLike object, not NoneType |  
20250424 14:20:05.708 | ERROR | Calling method '_start_keyword' of listener 'Browser' failed: TypeError: expected str, bytes or os.PathLike object, not NoneType
```

NOTE: This is robot 5.0.1.