### PR TITLE
ci: skip tests for pushes that change only markdown files

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -6,6 +6,8 @@ name: Continuous integration
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**/*.md'
   pull_request:
     branches: [ main ]
   schedule:


### PR DESCRIPTION
### Change Summary
Currently, the `Continuous integration` CI workflow will run even when a push changes **only markdown files** (e.g., CONTRIBUTING.md).

With these changes, a push that changes *only* markdown files will not trigger the workflow, thus **speeding up the project's CI** and **saving compute resources** 🌱 (see below for quantity).

### Example
Here is an example of the behaviour described above: the commit [`b82910c`](https://github.com/MarketSquare/robotframework-browser/commit/b82910ce476480ddd27e40ea05a719d259903bb9) changed these files: `CONTRIBUTING.md` and, when pushed, triggered [this](https://github.com/MarketSquare/robotframework-browser/actions/runs/12975956317) workflow run, which ran for ~1 CPU hours. With the proposed changes, these 1 CPU hours would have been saved, clearing the queue for other workflows and speeding up the CI of the project, while also saving resources in general. 

Note that this is a single example out of 2 examples over the last few months; a lower estimate for the accumulated gain is **2 CPU hours**, but the actual number could be higher because our cutoff date is late May and our data go only a few months back.

This only affects the `push` trigger and not the `pull_request` trigger, so the actions related to pull requests (opening, pushing new commits on an open PR, closing) will not be affected, only the pushes to branches which do not have an open pull request.

<details>
<summary>Click here to see all the recent CI runs triggered by markdown files.</summary>

[commit b82910c](https://github.com/MarketSquare/robotframework-browser/commit/b82910c) => [run url](https://github.com/MarketSquare/robotframework-browser/actions/runs/12975956317)
[commit 64ca5c1](https://github.com/MarketSquare/robotframework-browser/commit/64ca5c1) => [run url](https://github.com/MarketSquare/robotframework-browser/actions/runs/11083003388)

</details>

### Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on optimizations in GitHub Actions workflows.

Thanks for your time on this.

Kindly let us know (here or in the email below) if you would like to ignore other file types or apply the filter to other workflows/triggers, or if you have any question whatsoever.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch