### PR TITLE
Credentials as dictionary for HttpCredentials Example as robot variable

### DIFF
--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -443,7 +443,7 @@ class HttpCredentials(_HttpCredentials, total=False):
     | ***** *Variables* *****
     | ${username}=       admin
     | ${pwd}=            1234
-    | ${credentials}=    username=$username    password=$pwd
+    | &{credentials}=    username=$username    password=$pwd
     |
     | ***** *Keywords* *****
     | Open Context


### PR DESCRIPTION
The example for using the HttpCredentials with password and username as robot variable had a $ for the credentials but needs a dictionary & to be able to pass the two arguments.

Fixes #4573