### PR TITLE
Fix for issue #4644

### DIFF
--- a/Browser/keywords/getters.py
+++ b/Browser/keywords/getters.py
@@ -694,7 +694,7 @@ class Getters(LibraryComponent):
                 Request().ElementSelector(selector=selector, strict=False)
             )
             count = response.body
-            return float_str_verify_assertion(
+            return int_dict_verify_assertion(
                 int(count),
                 assertion_operator,
                 assertion_expected,


### PR DESCRIPTION
Get Element Count returns an int, so int_dict_verify_assertion should be used.