### PR TITLE
Add timeout to grpc closeContext, closeBrowser and closeAllBrowser calls

### DIFF
--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -148,9 +148,7 @@ class PlaywrightState(LibraryComponent):
             if browser != SelectionType.CURRENT:
                 self.switch_browser(browser)
 
-            response = stub.CloseBrowser(
-                Request.Empty(), timeout=self.timeout * 2
-            )
+            response = stub.CloseBrowser(Request.Empty(), timeout=self.timeout * 2)
             closed_browser_id = response.body
             self.delete_browser_id_from_arg_mapping(closed_browser_id)
             self._update_tracing_contexts()


### PR DESCRIPTION
This PR prevents tests being stuck on deadlock during closing context/browser as discussed in [this issue](https://github.com/MarketSquare/robotframework-browser/issues/4124):

I did not write new TCs since stub.closeContext(), closeBrowser() and closeAllBrowsers(), are covered in existing tests.

All tests has passed with `inv atest`.
<img width="566" height="68" alt="image" src="https://github.com/user-attachments/assets/bb568667-524b-4b7e-bf5f-83e571737eed" />

All unit tests has passed with `inv utest`.
<img width="245" height="30" alt="image" src="https://github.com/user-attachments/assets/5d6b0e4e-2a93-4370-aff7-10e6da3887a2" />


