### PR TITLE
chore: ignore protobuf 7.34.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "protobuf"
+        versions: ["7.34.1"]
     groups:
       grpc:
         patterns:


### PR DESCRIPTION
Because it is not compatible with grpcio-tools