### PR TITLE
docs: fix arguments table formatting in Set Presenter Mode keyword

### DIFF
--- a/Browser/keywords/browser_control.py
+++ b/Browser/keywords/browser_control.py
@@ -649,14 +649,12 @@ class Control(LibraryComponent):
         When enabled, elements are highlighted with a border for a duration to visually show what the keyword found.
 
         | =Arguments= | =Description= |
-        | ``mode`` | When set to ``True``, enables presenter mode with default settings. When set to ``False``, disables presenter mode.
-          Can also be a dictionary containing all highlighting configuration options as defined in ``HighLightElement``.
-          **All fields in the dictionary are required.**
+        | ``mode`` | When set to ``True``, enables presenter mode with default settings. When set to ``False``, disables presenter mode. Can also be a dictionary containing all highlighting configuration options as defined in ``HighLightElement``. All fields in the dictionary are required. |
 
         The keyword returns the previous presenter mode value, allowing you to restore it later.
 
         Example:
-        | ${old_mode}=    Set Presenter Mode    True
+        | ${old_mode} =    Set Presenter Mode    True
         | Click    //button                            # Element will be highlighted
         | Set Presenter Mode    ${old_mode}            # Restore previous mode
         |


### PR DESCRIPTION
Fixes #4811

The arguments table in `Set Presenter Mode` keyword documentation was broken due to multiline content and a missing trailing pipe (`|`), likely introduced by automated edits.

This change restores the table to a valid single-line format so it renders correctly.

Also updates the example to match the project's formatting conventions.