### PR TITLE
fix: Get Text returns option text instead of value for select elements

### DIFF
--- a/atest/test/02_Content_Keywords/basic_getters_get_text.robot
+++ b/atest/test/02_Content_Keywords/basic_getters_get_text.robot
@@ -37,7 +37,8 @@ Get Text Text Type As InputValue And Input Field
 
 Get Text No Text Type And Select Element
     Select Options By    id=pet-select    value    dog
-    Get Text    id=pet-select    ==    dog
+    ${text} =    Get Text    id=pet-select
+    Should Contain    ${text}    Dog
 
 Get Text Text Type As InputValue And Select Element
     Select Options By    id=pet-select    value    dog
@@ -112,7 +113,7 @@ Get Text With RegEx Match
 Get Text With Select Element
     Select Options By    id=pet-select    value    dog
     ${text} =    Get Text    id=pet-select
-    Should Be Equal    ${text}    dog
+    Should Contain    ${text}    Dog
     ${text} =    Get Text    id=pet-select    text_type=innerText
     FOR    ${item}    IN    Please choose an option    Dog    Cat    Hamster    Parrot    Spider    Goldfish
         Should Match    ${text}    *${item}*

--- a/node/playwright-wrapper/__tests__/getters.test.ts
+++ b/node/playwright-wrapper/__tests__/getters.test.ts
@@ -296,13 +296,13 @@ describe('getText', () => {
     }
 
     describe('when textType is ROBOT_FRAMEWORK_BROWSER_NO_SET', () => {
-        it('returns inputValue for a SELECT element', async () => {
+        it('returns innerText for a SELECT element', async () => {
             const locator = makeTextLocator({ evaluate: jest.fn().mockResolvedValue('SELECT') });
             mockFindLocator.mockResolvedValue(locator);
 
             const result = await getText(makeTextRequest(), {} as any);
 
-            expect(result.items).toEqual(['input text']);
+            expect(result.items).toEqual(['inner text']);
         });
 
         it('returns inputValue for an INPUT element', async () => {

--- a/node/playwright-wrapper/getters.ts
+++ b/node/playwright-wrapper/getters.ts
@@ -118,12 +118,13 @@ enum TextType {
 async function _getTextContentNoTextType(locator: Locator): Promise<string[]> {
     logger.info(`Getting text content without text type`);
     const tag = await locator.evaluate((e) => e.tagName);
-    if (tag === 'SELECT' || tag === 'TEXTAREA' || tag === 'INPUT') {
+    // <select> intentionally falls through to innerText() to restore pre-v20 (v19.12.0) behavior per issue #4953.
+    if (tag === 'TEXTAREA' || tag === 'INPUT') {
         logger.info(`Element is ${tag}, get inputValue`);
         const inputValue = await locator.inputValue();
         return [inputValue];
     } else {
-        logger.info(`Locator was not an <input>, <textarea>, or <select> element, falling back to innerText.`);
+        logger.info(`Locator was not an <input> or <textarea> element, falling back to innerText.`);
         const innerText = await locator.innerText();
         return [innerText];
     }

--- a/utest/test_get_text.py
+++ b/utest/test_get_text.py
@@ -8,8 +8,20 @@ class Response:
     items = ["element text"]
 
 
+class SelectResponse:
+    log = "Log text"
+    items = ["Dog"]
+
+
 def test_get_text(ctx: MagicMock):
     getter = Getters(ctx)
     getter._get_text = MagicMock(return_value=Response())  # type: ignore[assignment]
     text = getter.get_text("//div")
     assert text == "element text"
+
+
+def test_get_text_select_returns_option_text(ctx: MagicMock):
+    getter = Getters(ctx)
+    getter._get_text = MagicMock(return_value=SelectResponse())  # type: ignore[assignment]
+    text = getter.get_text("id=pet-select")
+    assert text == "Dog"


### PR DESCRIPTION
## What

Restores the pre-v20 behavior of `Get Text` on a `<select>` element so it returns the visible option text instead of the selected option's `value` attribute.

## Why

A regression landed between Browser library v19.12.0 and v20.0.0: `Get Text` on a `<select>` started returning the selected option's `value` attribute (e.g. `value_1`) instead of its visible text (e.g. `Berlin`). The cause is in `node/playwright-wrapper/getters.ts`: commit 6b5fe6b expanded the tag check in `_getTextContentNoTextType` from `INPUT`/`TEXTAREA` to also include `SELECT`, routing selects through `locator.inputValue()` (the value attribute) instead of `innerText()`.

In v19.12.0 a `<select>` fell through to `innerText()`. This PR removes `SELECT` from the `inputValue` branch so selects fall through to `innerText()` again, matching the original behavior. The explicit `text_type=inputValue` path is unchanged for callers who still want the value attribute.

## Changes

- `node/playwright-wrapper/getters.ts`: narrow the `inputValue` branch in `_getTextContentNoTextType` back to `TEXTAREA`/`INPUT` only; update the fallback log message; add a comment documenting the intentional `<select>` fall-through.
- `node/playwright-wrapper/__tests__/getters.test.ts`: update the `SELECT` no-text-type unit test to expect `innerText` instead of `inputValue`.
- `utest/test_get_text.py`: add a unit test documenting that select option text is returned unchanged through the keyword wrapper.
- `atest/test/02_Content_Keywords/basic_getters_get_text.robot`: update the select acceptance assertions to check the visible option text rather than the value attribute.

Fixes #4953
