### PR TITLE
Recognise the library's own keywords by identity, not by the name “Browser”

### DIFF
--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -30,7 +30,7 @@ from assertionengine import AssertionOperator
 from overrides import overrides
 from robot.api.deco import library
 from robot.errors import DataError
-from robot.libraries.BuiltIn import EXECUTION_CONTEXTS, BuiltIn
+from robot.libraries.BuiltIn import EXECUTION_CONTEXTS, BuiltIn, RobotNotRunningError
 from robot.running.arguments import PythonArgumentParser
 from robot.utils import secs_to_timestr, timestr_to_secs
 from robot.utils.robottypes import is_falsy
@@ -508,6 +508,7 @@ class Browser(DynamicCore):
         self.ROBOT_LIBRARY_LISTENER = self
         self.scope_stack: dict = {}
         self.suite_ids: dict[str, None] = {}
+        self._own_libname_cache: dict[str, bool] = {}
         self.current_test_id: str | None = None
         self._rf_context = _RFContextTracker()
         self._playwright_state: PlaywrightState = PlaywrightState(self)
@@ -860,7 +861,32 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
     def coverage_output(self) -> Path:
         return self.browser_output / "coverage"
 
+    def _is_own_keyword(self, libname: str) -> bool:
+        """Is ``libname`` the name *this* instance is imported under?
+
+        The listener is registered as ``self`` (``ROBOT_LIBRARY_LISTENER = self``), so the
+        listener hooks see every keyword in the suite and have to recognise their own.
+        Comparing ``libname`` against the literal ``"Browser"`` gets that wrong whenever
+        the library is imported ``AS`` another name or subclassed into a user library.
+
+        Identity is used rather than ``isinstance``: when a suite imports both ``Browser``
+        and a subclass of it, *both* instances are registered as listeners and both are
+        notified of every keyword, so an ``isinstance`` test would make each of them react
+        to the other's keywords.
+        """
+        cached = self._own_libname_cache.get(libname)
+        if cached is None:
+            try:
+                instances = BuiltIn().get_library_instance(all=True)
+            except RobotNotRunningError:
+                return False
+            cached = instances.get(libname) is self  # type: ignore[attr-defined]
+            self._own_libname_cache[libname] = cached
+        return cached
+
     def _start_suite(self, name, attrs):
+        # A name resolves to an instance within one namespace; a new suite is a new one.
+        self._own_libname_cache.clear()
         self.suite_ids[attrs["id"]] = None
         self._add_to_scope_stack(attrs["id"], Scope.Suite)
         self._rf_context.start_suite(attrs["id"], attrs.get("longname", name))
@@ -930,11 +956,13 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
         if not (
             self.show_keyword_call_banner is False
             or (self.show_keyword_call_banner is None and not self.presenter_mode)
-            or attrs["libname"] != "Browser"
             or attrs["status"] == "NOT RUN"
+            or not self._is_own_keyword(attrs["libname"])
         ):
             self._show_keyword_call(attrs)
-        if "secret" in attrs["kwname"].lower() and attrs["libname"] == "Browser":
+        if "secret" in attrs["kwname"].lower() and self._is_own_keyword(
+            attrs["libname"]
+        ):
             self._set_logging(False)
 
         if attrs["type"] == "Teardown":
@@ -1026,7 +1054,9 @@ def {name}(self, {", ".join(argument_names_and_default_values_texts)}):
             self.keyword_call_stack.pop()
         if self.tracing_group_mode == TracingGroupMode.Full:
             self._playwright_state.close_trace_group()
-        if "secret" in attrs["kwname"].lower() and attrs["libname"] == "Browser":
+        if "secret" in attrs["kwname"].lower() and self._is_own_keyword(
+            attrs["libname"]
+        ):
             self._set_logging(True)
 
     def _end_test(self, name, attrs):

--- a/utest/test_listener_own_keyword.py
+++ b/utest/test_listener_own_keyword.py
@@ -1,0 +1,141 @@
+from unittest.mock import patch
+
+import pytest
+from robot.libraries.BuiltIn import BuiltIn, RobotNotRunningError
+
+from Browser.browser import Browser
+
+
+class MyLib(Browser):
+    """A user library built by subclassing Browser, imported under its own name."""
+
+
+@pytest.fixture
+def browser():
+    return Browser()
+
+
+def _imported(mapping):
+    return patch.object(BuiltIn, "get_library_instance", return_value=mapping)
+
+
+def test_own_name_is_recognised(browser: Browser):
+    with _imported({"Browser": browser}):
+        assert browser._is_own_keyword("Browser") is True
+
+
+def test_alias_is_recognised(browser: Browser):
+    with _imported({"PW": browser}):
+        assert browser._is_own_keyword("PW") is True
+
+
+def test_name_not_imported_is_not_own(browser: Browser):
+    with _imported({"PW": browser}):
+        assert browser._is_own_keyword("Browser") is False
+
+
+def test_another_library_is_not_own(browser: Browser):
+    with _imported({"Browser": browser, "Collections": object()}):
+        assert browser._is_own_keyword("Collections") is False
+
+
+def test_subclass_recognises_its_own_name(browser: Browser):
+    my_lib = MyLib()
+    with _imported({"Browser": browser, "MyLib": my_lib}):
+        assert my_lib._is_own_keyword("MyLib") is True
+
+
+def test_instances_do_not_claim_each_others_keywords(browser: Browser):
+    """Both instances are registered as listeners and both see every keyword."""
+    my_lib = MyLib()
+    imported = {"Browser": browser, "MyLib": my_lib}
+    with _imported(imported):
+        assert browser._is_own_keyword("MyLib") is False
+        assert my_lib._is_own_keyword("Browser") is False
+
+
+def test_lookup_is_cached(browser: Browser):
+    with _imported({"Browser": browser}) as get_instance:
+        assert browser._is_own_keyword("Browser") is True
+        assert browser._is_own_keyword("Browser") is True
+    assert get_instance.call_count == 1
+
+
+def test_negative_lookup_is_cached(browser: Browser):
+    with _imported({"Browser": browser}) as get_instance:
+        assert browser._is_own_keyword("Collections") is False
+        assert browser._is_own_keyword("Collections") is False
+    assert get_instance.call_count == 1
+
+
+def test_cache_is_cleared_between_suites(browser: Browser):
+    with _imported({"PW": browser}):
+        assert browser._is_own_keyword("PW") is True
+    browser._own_libname_cache.clear()
+    with _imported({"PW": object()}):
+        assert browser._is_own_keyword("PW") is False
+
+
+def test_outside_a_robot_run_nothing_is_own(browser: Browser):
+    with patch.object(
+        BuiltIn, "get_library_instance", side_effect=RobotNotRunningError
+    ):
+        assert browser._is_own_keyword("Browser") is False
+    assert browser._own_libname_cache == {}
+
+
+def _run_listener_hooks(library, imported, libname, kwname="Fill Secret"):
+    """Drive the two listener hooks and report what they decided to do."""
+    attrs = {
+        "args": [],
+        "source": None,
+        "lineno": 1,
+        "type": "KEYWORD",
+        "status": "PASS",
+        "libname": libname,
+        "kwname": kwname,
+    }
+    shown: list = []
+    logging_calls: list = []
+    with (
+        patch.object(BuiltIn, "get_library_instance", return_value=imported),
+        patch.object(
+            Browser, "_show_keyword_call", lambda self, a: shown.append(a["libname"])
+        ),
+        patch.object(Browser, "_set_logging", lambda self, s: logging_calls.append(s)),
+    ):
+        library._start_keyword(kwname, attrs)
+        library._end_keyword(kwname, attrs)
+    return shown, logging_calls
+
+
+def test_listener_hooks_act_on_the_plain_import():
+    browser = Browser(show_keyword_call_banner=True)
+    shown, logging_calls = _run_listener_hooks(browser, {"Browser": browser}, "Browser")
+    assert shown == ["Browser"]
+    assert logging_calls == [False, True]
+
+
+def test_listener_hooks_act_on_an_aliased_import():
+    browser = Browser(show_keyword_call_banner=True)
+    shown, logging_calls = _run_listener_hooks(browser, {"PW": browser}, "PW")
+    assert shown == ["PW"]
+    assert logging_calls == [False, True]
+
+
+def test_listener_hooks_act_on_a_subclassed_import(browser: Browser):
+    my_lib = MyLib(show_keyword_call_banner=True)
+    shown, logging_calls = _run_listener_hooks(
+        my_lib, {"Browser": browser, "MyLib": my_lib}, "MyLib"
+    )
+    assert shown == ["MyLib"]
+    assert logging_calls == [False, True]
+
+
+def test_listener_hooks_ignore_another_librarys_keyword():
+    browser = Browser(show_keyword_call_banner=True)
+    shown, logging_calls = _run_listener_hooks(
+        browser, {"Browser": browser, "Collections": object()}, "Collections"
+    )
+    assert shown == []
+    assert logging_calls == []


### PR DESCRIPTION
Fixes #5154.

## What changes

The three listener hooks stop asking *"is this keyword called `Browser`?"* and start
asking *"is this keyword mine?"* — `attrs["libname"]` is resolved to a library instance
and compared with `self`:

* `_start_keyword` — the keyword-call banner gate (`browser.py:935`)
* `_start_keyword` — the secret log suppression (`browser.py:939`)
* `_end_keyword` — its restore (`browser.py:1031`)

The lookup goes through `BuiltIn().get_library_instance(all=True)` and is cached per
library name, because these hooks fire on **every** keyword in the suite, not only on
ours. The cache is cleared in `_start_suite`, since a name only resolves to an instance
within one namespace. The condition order in `_start_keyword` is changed so the two
cheap boolean tests short-circuit before the resolution — the operands are pure, so the
meaning is unchanged.

## Reproduced first, on the unpatched tree

Four real `robot` runs. No browser is needed for this: the listener hooks fire *before*
the keyword body, so a keyword that then fails for want of a browser still records the
decision. `_show_keyword_call` and `_set_logging` were patched to record their caller
and arguments; everything else is the library as shipped.

| Suite | Import | before | after |
| --- | --- | --- | --- |
| `plain` | `Library Browser` | banner + suppress/restore | unchanged |
| `alias` | `Library Browser AS PW` | **nothing at all** | banner + suppress/restore |
| `subclass` | `Library mylib.py` where `class MyLib(Browser)` | **nothing at all** | banner + suppress/restore |
| `both` | `Browser` **and** `MyLib` together | see below | one instance per keyword |

That last row is worth a second look, because it is a defect in the *current* behaviour
rather than a missing one. With both imported, `Browser.Click` produced **two**
`_show_keyword_call` calls — one of them from the `MyLib` instance, which does not own
that keyword and may not even have a page open — while `MyLib.Click` produced none.

## The one place this departs from the suggested fix, and it was measured

The issue suggests `isinstance(instance, Browser)`. I ran both, changing only that line.

Both instances are registered as listeners (`ROBOT_LIBRARY_LISTENER = self`) and both are
notified of every keyword, so under `isinstance` each one claims the other's keywords.
The banner half of that is cosmetic. `_set_logging` is not: it stashes the previous level
on `self` but sets a **global** one, so around a single `Fill Secret` the two instances
interleave —

```
isinstance   Browser  suppress -> global NONE, stashed INFO
             MyLib    suppress -> global NONE, stashed NONE   <-- stashes the clamp
             Browser  restore  -> global INFO
             MyLib    restore  -> global NONE                 <-- and puts it back
```

— and the run is left at `NONE`. In the probe the `Log    after the secret keyword`
that follows is present in `output.xml` as a `<msg>` element under identity and absent
under `isinstance`. Identity gives one listener per keyword and no interleaving.

If you would rather have `isinstance` anyway, it is one line in `_is_own_keyword` and I
am happy to change it — but the `_set_logging` interleaving would want handling
separately.

## Tests

`utest/test_listener_own_keyword.py`, 14 tests. Ten cover `_is_own_keyword` directly
(own name, alias, a name that is not ours, another library, subclass, two instances not
claiming each other, caching in both directions, the cache clearing, and
`RobotNotRunningError` — which is unreachable from a listener hook and defensive only).
Four drive `_start_keyword`/`_end_keyword` and assert what they decided; **two of those
four fail on `main`** and are the actual regression guard.

## What I did not run, and what I checked instead

* **`inv atest` was not run.** It needs a node build and Playwright browsers; this
  machine has neither. **Please treat CI as the authority**, and note that I have
  therefore *not* seen a `<style id="kwCallBanner">` element appear in a real page under
  an aliased import — I have only seen `_show_keyword_call` reached with the right
  instance. The issue's own `Get Element Count` measurement is the check I could not
  repeat.
* `inv utest` on this tree: **13 failed, 298 passed, 2 skipped, 23 errors** — and
  **identical** before and after the patch apart from my 14 new passes. Every failure is
  `Couldn't find node` or a missing `node/dynamic-test-app` build.
* `ruff format --check`, `ruff check`: clean on both changed files; the repo-wide counts
  (40 findings in other `utest` files under ruff 0.16.3) are unchanged by this patch.
* `mypy --config-file Browser/mypy.ini Browser/`: **22 errors before, 22 after**. They
  are all `playwright_pb2` stub and `BrowserBatteries` artefacts of a hand-generated
  protobuf on this box. The `# type: ignore[attr-defined]` on the
  `get_library_instance` result mirrors the one already on `waiter.py:299`.

Built and verified against `cd1f8544a2`.
