### PR TITLE
Add mode, depth and boxes arguments to Get Aria Snapshot #5101

### DIFF
--- a/Browser/gen_stub.py
+++ b/Browser/gen_stub.py
@@ -69,7 +69,7 @@ from Browser.utils import (
 from Browser.utils .data_types import (
     ClientCredential, MouseButton, KeyboardModifier, ScrollBehavior, ScrollBehavior, DialogAction, MouseButtonAction,
     NotSet, Dimensions, SizeFields, AreaFields, BoundingBoxFields, SelectionStrategy, ElementRole,
-     AriaSnapshotReturnType, KeyboardInputAction, KeyAction, TextType
+     AriaSnapshotMode, AriaSnapshotReturnType, KeyboardInputAction, KeyAction, TextType
 )
 from Browser.utils.types import Secret
 """

--- a/Browser/keywords/getters.py
+++ b/Browser/keywords/getters.py
@@ -40,6 +40,7 @@ from ..utils import keyword, logger
 from ..utils.data_types import (
     ROBOT_FRAMEWORK_BROWSER_NO_SET,
     AreaFields,
+    AriaSnapshotMode,
     AriaSnapshotReturnType,
     BoundingBox,
     BoundingBoxFields,
@@ -69,6 +70,10 @@ class Getters(LibraryComponent):
         assertion_operator: AssertionOperator | None = None,
         assertion_expected: Any | None = None,
         message: str | None = None,
+        *,
+        mode: AriaSnapshotMode = AriaSnapshotMode.default,
+        depth: int | None = None,
+        boxes: bool = False,
     ) -> str | dict | tuple:
         """Returns the aria snapshot of the element found by ``selector``.
 
@@ -78,8 +83,20 @@ class Getters(LibraryComponent):
         | ``assertion_operator`` | See `Assertions` for further details. Defaults to None. |
         | ``assertion_expected`` | Expected value for the state |
         | ``message`` | overrides the default error message for assertion. |
+        | ``mode`` | Defines the snapshot mode. Possible values are ``default`` (default) and ``ai``. See `AriaSnapshotMode` for more details. |
+        | ``depth`` | Limits the snapshot to the given number of tree levels. Must be a positive integer. Defaults to ``None``, which does not limit the depth. |
+        | ``boxes`` | If ``True``, the bounding box of each element is appended to its line as ``[box=x,y,width,height]``. Coordinates are relative to the viewport, in CSS pixels. Defaults to ``False``. |
 
         Keyword uses strict mode, see `Finding elements` for more details about strict mode.
+
+        With ``mode=ai`` the snapshot is optimized for AI consumption: it contains element
+        references like ``[ref=e2]`` and the content of iframes inside the element. It also
+        does not wait for a matching element, but fails immediately when no element matches,
+        instead of failing with a timeout like the ``default`` mode does.
+
+        With ``return_type=dict`` the YAML returned by Playwright is loaded as is. The
+        ``[ref=...]`` and ``[box=...]`` annotations are therefore part of the dictionary
+        keys, not separate entries.
 
         Optionally asserts that the snapshot matches the specified assertion. See
         `Assertions` for further details for the assertion arguments. By default assertion
@@ -90,13 +107,25 @@ class Getters(LibraryComponent):
         | Log Many    ${aria}
         | ${aria_dict} =    `Get Aria Snapshot`    id=main    dict   # returns dictionary
         | Log Many    ${aria_dict}
+        | ${aria} =    `Get Aria Snapshot`    css=nav    depth=2   # only two levels of the tree
+        | ${aria} =    `Get Aria Snapshot`    css=body    mode=ai   # with [ref=...] annotations
+        | ${aria} =    `Get Aria Snapshot`    id=main    boxes=True   # with [box=...] annotations
+        | `Get Aria Snapshot`    css=nav    depth=2    contains    link "Home"
 
         [https://forum.robotframework.org/t//4303|Comment >>]
         """
+        if depth is not None and depth <= 0:
+            raise ValueError(f"depth must be a positive integer, but got: {depth}")
         selector = self.presenter_mode(selector, self.strict_mode)
         with self.playwright.grpc_channel() as stub:
             response = stub.AriaSnapShot(
-                Request.AriaSnapShot(locator=selector, strict=self.strict_mode)
+                Request.AriaSnapShot(
+                    locator=selector,
+                    strict=self.strict_mode,
+                    mode="ai" if mode is AriaSnapshotMode.ai else "",
+                    depth=depth or 0,
+                    boxes=boxes,
+                )
             )
         logger.info(response.log)
         value = response.body

--- a/Browser/keywords/getters.py
+++ b/Browser/keywords/getters.py
@@ -37,6 +37,7 @@ from ..assertion_engine import assertion_formatter_used, with_assertion_polling
 from ..base import LibraryComponent
 from ..generated.playwright_pb2 import Request
 from ..utils import keyword, logger
+from ..utils.aria_snapshot import parse_aria_snapshot
 from ..utils.data_types import (
     ROBOT_FRAMEWORK_BROWSER_NO_SET,
     AreaFields,
@@ -74,12 +75,12 @@ class Getters(LibraryComponent):
         mode: AriaSnapshotMode = AriaSnapshotMode.default,
         depth: int | None = None,
         boxes: bool = False,
-    ) -> str | dict | tuple:
+    ) -> str | dict | list | tuple:
         """Returns the aria snapshot of the element found by ``selector``.
 
         | =Arguments= | =Description= |
         | ``selector`` | Selector from which the info is to be retrieved. See the `Finding elements` section for details about the selectors. |
-        | ``return_type`` | Defines the return type. Possible values are ``yaml`` (default) and ``dict``. If ``yaml`` is selected, the returned value is a string in YAML format. If ``dict`` is selected, the returned value is a dictionary. |
+        | ``return_type`` | Defines the return type. Possible values are ``yaml`` (default), ``dict`` and ``parsed``. If ``yaml`` is selected, the returned value is a string in YAML format. If ``dict`` is selected, the returned value is a dictionary. If ``parsed`` is selected, the returned value is a tree of node dictionaries. See `AriaSnapshotReturnType` for more details. |
         | ``assertion_operator`` | See `Assertions` for further details. Defaults to None. |
         | ``assertion_expected`` | Expected value for the state |
         | ``message`` | overrides the default error message for assertion. |
@@ -96,7 +97,8 @@ class Getters(LibraryComponent):
 
         With ``return_type=dict`` the YAML returned by Playwright is loaded as is. The
         ``[ref=...]`` and ``[box=...]`` annotations are therefore part of the dictionary
-        keys, not separate entries.
+        keys, not separate entries. Use ``return_type=parsed`` to get them as separate
+        values of each node.
 
         Optionally asserts that the snapshot matches the specified assertion. See
         `Assertions` for further details for the assertion arguments. By default assertion
@@ -107,10 +109,6 @@ class Getters(LibraryComponent):
         | Log Many    ${aria}
         | ${aria_dict} =    `Get Aria Snapshot`    id=main    dict   # returns dictionary
         | Log Many    ${aria_dict}
-        | ${aria} =    `Get Aria Snapshot`    css=nav    depth=2   # only two levels of the tree
-        | ${aria} =    `Get Aria Snapshot`    css=body    mode=ai   # with [ref=...] annotations
-        | ${aria} =    `Get Aria Snapshot`    id=main    boxes=True   # with [box=...] annotations
-        | `Get Aria Snapshot`    css=nav    depth=2    contains    link "Home"
 
         [https://forum.robotframework.org/t//4303|Comment >>]
         """
@@ -132,6 +130,8 @@ class Getters(LibraryComponent):
         logger.info(f"Aria Snapshot: {value}")
         if return_type is AriaSnapshotReturnType.dict:
             value = yaml.safe_load(value) if value else {}
+        elif return_type is AriaSnapshotReturnType.parsed:
+            value = parse_aria_snapshot(value)
         formatter = self.get_assertion_formatter("Get Aria Snapshot")
         return verify_assertion(
             value,

--- a/Browser/keywords/getters.py
+++ b/Browser/keywords/getters.py
@@ -76,11 +76,11 @@ class Getters(LibraryComponent):
         depth: int | None = None,
         boxes: bool = False,
     ) -> str | dict | list | tuple:
-        """Returns the aria snapshot of the element found by ``selector``.
+        """Returns the aria snapshot of the element found by ``selector``. See `AriaSnapshotReturnType` for more details and examples.
 
         | =Arguments= | =Description= |
         | ``selector`` | Selector from which the info is to be retrieved. See the `Finding elements` section for details about the selectors. |
-        | ``return_type`` | Defines the return type. Possible values are ``yaml`` (default), ``dict`` and ``parsed``. If ``yaml`` is selected, the returned value is a string in YAML format. If ``dict`` is selected, the returned value is a dictionary. If ``parsed`` is selected, the returned value is a tree of node dictionaries. See `AriaSnapshotReturnType` for more details. |
+        | ``return_type`` | Defines the return type. Possible values are ``yaml`` (default), ``dict`` and ``parsed``. If ``yaml`` is selected, the returned value is a string in YAML format. If ``dict`` is selected, the returned value is a dictionary. If ``parsed`` is selected, the returned value is a tree of node dictionaries. |
         | ``assertion_operator`` | See `Assertions` for further details. Defaults to None. |
         | ``assertion_expected`` | Expected value for the state |
         | ``message`` | overrides the default error message for assertion. |

--- a/Browser/utils/aria_snapshot.py
+++ b/Browser/utils/aria_snapshot.py
@@ -1,0 +1,110 @@
+# Copyright 2020-     Robot Framework Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+from typing import Any
+
+import yaml
+from robot.utils import DotDict
+
+_LABEL = re.compile(
+    r"""
+    ^(?P<role>\S+)
+    (?:\s+"(?P<name>(?:[^"\\]|\\.)*)")?
+    (?P<properties>(?:\s*\[[^\]]*\])*)
+    \s*$
+    """,
+    re.VERBOSE,
+)
+_PROPERTY = re.compile(r"\[([^\]]*)\]")
+_INTEGER = re.compile(r"^-?\d+$")
+_BOX_FIELDS = ("x", "y", "width", "height")
+
+
+def parse_aria_snapshot(snapshot: str) -> list[DotDict]:
+    """Turns Playwright's aria snapshot YAML into a tree of node dictionaries.
+
+    Every node has the keys ``role``, ``name``, ``text``, ``props`` and
+    ``children``. Nodes are ``DotDict``s, so their values are reachable both as
+    ``node["role"]`` and as ``node.role``.
+    """
+    if not snapshot:
+        return []
+    return _to_nodes(yaml.safe_load(snapshot))
+
+
+def _to_nodes(loaded: Any) -> list[DotDict]:
+    if not loaded:
+        return []
+    return [_to_node(entry) for entry in loaded]
+
+
+def _to_node(entry: Any) -> DotDict:
+    if isinstance(entry, dict):
+        [(label, content)] = entry.items()
+        return _node(label, content)
+    return _node(entry, None)
+
+
+def _node(label: str, content: Any) -> DotDict:
+    node = _parse_label(label)
+    if isinstance(content, list):
+        node.children = _hoist_properties(node, content)
+    elif content is not None:
+        node.text = str(content)
+    return node
+
+
+def _hoist_properties(node: DotDict, content: list) -> list[DotDict]:
+    """Playwright renders link targets as a ``/url`` child, not as an element."""
+    children = []
+    for entry in content:
+        if isinstance(entry, dict):
+            [(label, value)] = entry.items()
+            if label.startswith("/"):
+                node.props[label[1:]] = value
+                continue
+        children.append(_to_node(entry))
+    return children
+
+
+def _parse_label(label: str) -> DotDict:
+    match = _LABEL.match(label)
+    if not match:
+        return DotDict(role=label, name=None, text=None, props=DotDict(), children=[])
+    name = match["name"]
+    return DotDict(
+        role=match["role"],
+        name=None if name is None else name.replace('\\"', '"'),
+        text=None,
+        props=_parse_properties(match["properties"]),
+        children=[],
+    )
+
+
+def _parse_properties(properties: str) -> DotDict:
+    parsed = DotDict()
+    for property_ in _PROPERTY.findall(properties):
+        name, separator, value = property_.partition("=")
+        parsed[name] = _parse_property_value(name, value) if separator else True
+    return parsed
+
+
+def _parse_property_value(name: str, value: str) -> Any:
+    if name == "box":
+        coordinates = value.split(",")
+        if len(coordinates) == len(_BOX_FIELDS):
+            return DotDict(zip(_BOX_FIELDS, [int(c) for c in coordinates], strict=True))
+    if _INTEGER.match(value):
+        return int(value)
+    return value

--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -196,20 +196,208 @@ class AriaSnapshotReturnType(Enum):
 
     ``parsed`` splits that information into separate keys. Every node has
     ``role``, ``name``, ``text``, ``props`` and ``children``, and its values
-    are reachable both as ``${node}[role]`` and as ``${node.role}``:
+    are reachable both as ``${node}[role]`` and as ``${node.role}``.
+    Annotations without a value, like ``[selected]``, become ``True``,
+    ``[level=2]`` becomes an integer and ``box`` uses the same keys as
+    `Get BoundingBox`. The ``/url`` entry of a link is an annotation in
+    Playwright, not an element, and therefore becomes the ``url`` property of
+    the link instead of one of its children.
 
-    | {
-    |     "role": "textbox",
-    |     "name": "username",
-    |     "text": None,
-    |     "props": {"ref": "e10", "box": {"x": 553, "y": 76, "width": 186, "height": 18}},
-    |     "children": []
-    | }
+    == Examples ==
 
-    Annotations without a value, like ``[selected]``, become ``True``.
-    ``box`` uses the same keys as `Get BoundingBox`. The ``/url`` entry of a
-    link is an annotation in Playwright, not an element, and therefore becomes
-    the ``url`` property of the link instead of one of its children.
+    All outputs below come from the same element of the same page. It offers
+    fourteen tag options; the examples stop after the fourth one:
+
+    | `New Browser`    chromium
+    | `New Page`       https://robotframework-browser.org/keywords
+    | ${snapshot} =    `Get Aria Snapshot`    .rail-top
+
+    === return_type=yaml (default) ===
+
+    | - text: Filter keywords
+    | - searchbox "Filter keywords"
+    | - group: Version 20.3.0
+    | - text: Filter by tag
+    | - combobox "Filter by tag":
+    |   - option "— Show all tags —" [selected]
+    |   - option "Setter (84)"
+    |   - option "PageContent (83)"
+    |   - option "Getter (45)"
+
+    === return_type=yaml with boxes=True ===
+
+    | - text: Filter keywords
+    | - searchbox "Filter keywords" [box=12,77,279,30]
+    | - group [box=12,116,279,34]: Version 20.3.0
+    | - text: Filter by tag
+    | - combobox "Filter by tag" [box=12,158,279,32]:
+    |   - option "— Show all tags —" [selected] [box=0,0,0,0]
+    |   - option "Setter (84)" [box=0,0,0,0]
+    |   - option "PageContent (83)" [box=0,0,0,0]
+    |   - option "Getter (45)" [box=0,0,0,0]
+
+    === return_type=yaml with boxes=True and mode=ai ===
+
+    | - generic [ref=f2e1] [box=0,65,303,137]:
+    |   - generic [ref=f2e3] [box=12,77,279,30]:
+    |     - generic [ref=f2e4] [box=12,77,1,1]: Filter keywords
+    |     - searchbox "Filter keywords" [ref=f2e5] [box=12,77,279,30]
+    |   - generic [ref=f2e6] [box=12,116,279,74]:
+    |     - group [ref=f2e7] [box=12,116,279,34]:
+    |       - generic "Version 20.3.0" [ref=f2e8] [cursor=pointer] [box=12,116,157,34]:
+    |         - generic [ref=f2e9] [box=22,124,66,18]: Version
+    |         - generic [ref=f2e10] [box=96,121,49,22]: 20.3.0
+    |     - generic [ref=f2e12] [box=12,158,279,32]:
+    |       - generic [ref=f2e13] [box=12,158,1,1]: Filter by tag
+    |       - combobox "Filter by tag" [ref=f2e14] [box=12,158,279,32]:
+    |         - option "— Show all tags —" [selected] [box=0,0,0,0]
+    |         - option "Setter (84)" [box=0,0,0,0]
+    |         - option "PageContent (83)" [box=0,0,0,0]
+    |         - option "Getter (45)" [box=0,0,0,0]
+
+    === return_type=dict with boxes=True ===
+
+    | [
+    |   {
+    |     'text': 'Filter keywords'
+    |   },
+    |   'searchbox "Filter keywords" [box=12,77,279,30]',
+    |   {
+    |     'group [box=12,116,279,34]': 'Version 20.3.0'
+    |   },
+    |   {
+    |     'text': 'Filter by tag'
+    |   },
+    |   {
+    |     'combobox "Filter by tag" [box=12,158,279,32]': [
+    |       'option "— Show all tags —" [selected] [box=0,0,0,0]',
+    |       'option "Setter (84)" [box=0,0,0,0]',
+    |       'option "PageContent (83)" [box=0,0,0,0]'
+    |       'option "Getter (45)" [box=0,0,0,0]'
+    |     ]
+    |   }
+    | ]
+
+    === return_type=parsed with boxes=True ===
+
+    Fully parsed snapshot as Robot Framework dictionary:
+
+    | [
+    |   {
+    |     'role': 'text',
+    |     'name': None,
+    |     'text': 'Filter keywords',
+    |     'props': {},
+    |     'children': []
+    |   },
+    |   {
+    |     'role': 'searchbox',
+    |     'name': 'Filter keywords',
+    |     'text': None,
+    |     'props': {
+    |       'box': {
+    |         'x': 12,
+    |         'y': 77,
+    |         'width': 279,
+    |         'height': 30
+    |       }
+    |     },
+    |     'children': []
+    |   },
+    |   {
+    |     'role': 'group',
+    |     'name': None,
+    |     'text': 'Version 20.3.0',
+    |     'props': {
+    |       'box': {
+    |         'x': 12,
+    |         'y': 116,
+    |         'width': 279,
+    |         'height': 34
+    |       }
+    |     },
+    |     'children': []
+    |   },
+    |   {
+    |     'role': 'text',
+    |     'name': None,
+    |     'text': 'Filter by tag',
+    |     'props': {},
+    |     'children': []
+    |   },
+    |   {
+    |     'role': 'combobox',
+    |     'name': 'Filter by tag',
+    |     'text': None,
+    |     'props': {
+    |       'box': {
+    |         'x': 12,
+    |         'y': 158,
+    |         'width': 279,
+    |         'height': 32
+    |       }
+    |     },
+    |     'children': [
+    |       {
+    |         'role': 'option',
+    |         'name': '— Show all tags —',
+    |         'text': None,
+    |         'props': {
+    |           'selected': True,
+    |           'box': {
+    |             'x': 0,
+    |             'y': 0,
+    |             'width': 0,
+    |             'height': 0
+    |           }
+    |         },
+    |         'children': []
+    |       },
+    |       {
+    |         'role': 'option',
+    |         'name': 'Setter (84)',
+    |         'text': None,
+    |         'props': {
+    |           'box': {
+    |             'x': 0,
+    |             'y': 0,
+    |             'width': 0,
+    |             'height': 0
+    |           }
+    |         },
+    |         'children': []
+    |       },
+    |       {
+    |         'role': 'option',
+    |         'name': 'PageContent (83)',
+    |         'text': None,
+    |         'props': {
+    |           'box': {
+    |             'x': 0,
+    |             'y': 0,
+    |             'width': 0,
+    |             'height': 0
+    |           }
+    |         },
+    |         'children': []
+    |       },
+    |       {
+    |         'role': 'option',
+    |         'name': 'Getter (45)',
+    |         'text': None,
+    |         'props': {
+    |           'box': {
+    |             'x': 0,
+    |             'y': 0,
+    |             'width': 0,
+    |             'height': 0
+    |           }
+    |         },
+    |         'children': []
+    |       }
+    |     ]
+    |   }
+    | ]
     """
 
     dict = auto()

--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -188,10 +188,33 @@ class AriaSnapshotReturnType(Enum):
     | =Value=  | =Description= |
     | ``dict`` | returns the snapshot as a dictionary. |
     | ``yaml`` | returns the snapshot as a yaml string. |
+    | ``parsed`` | returns the snapshot as a tree of node dictionaries. |
+
+    ``dict`` loads the yaml as it is. Role, name and all annotations of an
+    element stay inside the dictionary keys, for example
+    ``{'heading "Login Page" [level=1]': None}``.
+
+    ``parsed`` splits that information into separate keys. Every node has
+    ``role``, ``name``, ``text``, ``props`` and ``children``, and its values
+    are reachable both as ``${node}[role]`` and as ``${node.role}``:
+
+    | {
+    |     "role": "textbox",
+    |     "name": "username",
+    |     "text": None,
+    |     "props": {"ref": "e10", "box": {"x": 553, "y": 76, "width": 186, "height": 18}},
+    |     "children": []
+    | }
+
+    Annotations without a value, like ``[selected]``, become ``True``.
+    ``box`` uses the same keys as `Get BoundingBox`. The ``/url`` entry of a
+    link is an annotation in Playwright, not an element, and therefore becomes
+    the ``url`` property of the link instead of one of its children.
     """
 
     dict = auto()
     yaml = auto()
+    parsed = auto()
 
 
 class KeywordCallStackEntry(TypedDict):

--- a/Browser/utils/data_types.py
+++ b/Browser/utils/data_types.py
@@ -170,6 +170,18 @@ class NotSet(Enum):
     not_set = "not_set"
 
 
+class AriaSnapshotMode(Enum):
+    """Defines the mode of the AriaSnapshot.
+
+    | =Value=     | =Description= |
+    | ``default`` | Standard aria snapshot. |
+    | ``ai`` | Snapshot optimized for AI consumption. It includes element references like ``[ref=e2]``, includes snapshots of iframes inside the target and does not wait for a matching element, but fails immediately when no element matches. |
+    """
+
+    default = auto()
+    ai = auto()
+
+
 class AriaSnapshotReturnType(Enum):
     """Defines the return type of the AriaSnapshot.
 

--- a/atest/test/02_Content_Keywords/aria_snapshot.robot
+++ b/atest/test/02_Content_Keywords/aria_snapshot.robot
@@ -4,7 +4,8 @@ Resource        imports.resource
 Suite Setup     Aria Snapshot Setup
 
 *** Variables ***
-${MouseTable} =     css=table >> nth=1
+${MouseTable} =         css=table >> nth=1
+${LEFT_FRAME_URL} =     ${ROOT_URL}frames/left.html
 
 *** Test Cases ***
 Aria Snapshot YAML
@@ -107,14 +108,38 @@ Aria Snapshot Parsed
     Should Be Equal    ${nodes}[0][text]    ${None}
     Should Be Empty    ${nodes}[0][children]
 
-Aria Snapshot Parsed Nests Children
-    ${nodes} =    Get Aria Snapshot    ${MouseTable}    parsed
-    ${rowgroup} =    Set Variable    ${nodes}[0][children][0]
-    ${first_cell} =    Set Variable    ${rowgroup}[children][0][children][0]
-    Should Be Equal    ${nodes}[0][role]    table
-    Should Be Equal    ${rowgroup}[role]    rowgroup
-    Should Be Equal    ${first_cell}[role]    cell
-    Should Be Equal    ${first_cell}[name]    Upload Result:
+Aria Snapshot Parsed Complete Structure
+    [Documentation]    Covers every node key in both of its shapes: named and unnamed nodes,
+    ...    nodes with and without text, a hoisted ``/url`` property next to nodes without
+    ...    properties, and two levels of nesting with three siblings. The page renders as:
+    ...    - paragraph: "This is LEFT side. Links:"
+    ...    - list:
+    ...    ${SPACE*2}- listitem:
+    ...    ${SPACE*4}- text: Open
+    ...    ${SPACE*4}- link "foo":
+    ...    ${SPACE*6}- /url: foo.html
+    ...    ${SPACE*4}- text: on the right-hand side frame
+    ...    - paragraph: "Form:"
+    ...    - textbox
+    ...    - button "Search"
+    Ensure Location    ${LEFT_FRAME_URL}
+    ${nodes} =    Get Aria Snapshot    css=body    parsed
+    VAR    ${literal} =
+    ...    [
+    ...    {'role': 'paragraph', 'name': None, 'text': 'This is LEFT side. Links:', 'props': {}, 'children': []},
+    ...    {'role': 'list', 'name': None, 'text': None, 'props': {}, 'children': [
+    ...    {'role': 'listitem', 'name': None, 'text': None, 'props': {}, 'children': [
+    ...    {'role': 'text', 'name': None, 'text': 'Open', 'props': {}, 'children': []},
+    ...    {'role': 'link', 'name': 'foo', 'text': None, 'props': {'url': 'foo.html'}, 'children': []},
+    ...    {'role': 'text', 'name': None, 'text': 'on the right-hand side frame', 'props': {}, 'children': []},]},]},
+    ...    {'role': 'paragraph', 'name': None, 'text': 'Form:', 'props': {}, 'children': []},
+    ...    {'role': 'textbox', 'name': None, 'text': None, 'props': {}, 'children': []},
+    ...    {'role': 'button', 'name': 'Search', 'text': None, 'props': {}, 'children': []},
+    ...    ]
+    ...    separator=${SPACE}
+    ${expected} =    Evaluate    ${literal}
+    Should Be Equal    ${nodes}    ${expected}
+    [Teardown]    Ensure Location    ${LOGIN_URL}
 
 Aria Snapshot Parsed With Boxes Matches Get BoundingBox
     ${box} =    Get BoundingBox    h1    ALL

--- a/atest/test/02_Content_Keywords/aria_snapshot.robot
+++ b/atest/test/02_Content_Keywords/aria_snapshot.robot
@@ -3,6 +3,9 @@ Resource        imports.resource
 
 Suite Setup     Aria Snapshot Setup
 
+*** Variables ***
+${MouseTable} =     css=table >> nth=1
+
 *** Test Cases ***
 Aria Snapshot YAML
     ${snapshot} =    Get Aria Snapshot    h1
@@ -35,6 +38,69 @@ Aria Snapshot Non-existing Element
         Log    Caught expected PlaywrightError for non-existing element.
     END
 
+Aria Snapshot Depth
+    ${full} =    Get Aria Snapshot    ${MouseTable}
+    ${depth_1} =    Get Aria Snapshot    ${MouseTable}    depth=1
+    ${depth_2} =    Get Aria Snapshot    ${MouseTable}    depth=2
+    Should Be Equal    ${depth_1}    - table:\n${SPACE*2}- rowgroup
+    Should Contain    ${depth_2}    - row "Mouse Delay:"
+    Should Not Contain    ${depth_2}    - cell "Mouse Delay:"
+    Should Contain    ${full}    - cell "Mouse Delay:"
+
+Aria Snapshot Depth With Assertion
+    Get Aria Snapshot    ${MouseTable}    yaml    contains    - row "Mouse Delay:"    depth=2
+
+Aria Snapshot Invalid Depth
+    FOR    ${depth}    IN    ${0}    ${-1}
+        TRY
+            Get Aria Snapshot    ${MouseTable}    depth=${depth}
+        EXCEPT    ValueError: depth must be a positive integer, but got: ${depth}
+            Log    Failed as expected with depth ${depth}.
+        END
+    END
+
+Aria Snapshot Boxes
+    ${expected} =    Aria Box Annotation Of    h1
+    ${snapshot} =    Get Aria Snapshot    h1    boxes=True
+    Should Be Equal    ${snapshot}    - heading "Login Page" [level=1] ${expected}
+    ${without_boxes} =    Get Aria Snapshot    h1
+    Should Not Contain    ${without_boxes}    [box=
+
+Aria Snapshot AI Mode
+    ${snapshot} =    Get Aria Snapshot    h1    mode=ai
+    Should Match Regexp    ${snapshot}    ^- heading "Login Page" \\[level=1\\] \\[ref=\\w+\\]$
+    ${default_mode} =    Get Aria Snapshot    h1
+    Should Not Contain    ${default_mode}    [ref=
+
+Aria Snapshot AI Mode Includes Iframes
+    Ensure Location    ${FRAMES_URL}
+    ${default_mode} =    Get Aria Snapshot    css=body
+    Should Not Contain    ${default_mode}    This is LEFT side.
+    ${snapshot} =    Get Aria Snapshot    css=body    mode=ai
+    Should Contain    ${snapshot}    This is LEFT side.
+    Should Contain    ${snapshot}    This is RIGHT side.
+    [Teardown]    Ensure Location    ${LOGIN_URL}
+
+Aria Snapshot AI Mode Non-existing Element
+    TRY
+        Get Aria Snapshot    id=non_existing_element    mode=ai
+    EXCEPT    *does not match any element*    type=glob
+        Log    Caught expected PlaywrightError without waiting for a timeout.
+    END
+
+Aria Snapshot Options With Dict Return Type
+    ${expected_box} =    Aria Box Annotation Of    h1
+    VAR    @{expected} =    heading "Login Page" [level=1] ${expected_box}
+    ${snapshot} =    Get Aria Snapshot    h1    dict    boxes=True
+    Should Be Equal    ${snapshot}    ${expected}
+
 *** Keywords ***
 Aria Snapshot Setup
     Ensure Open Page    ${LOGIN_URL}
+
+Aria Box Annotation Of
+    [Arguments]    ${selector}
+    ${box} =    Get BoundingBox    ${selector}    ALL
+    ${annotation} =    Evaluate
+    ...    "[box=%d,%d,%d,%d]" % (int($box["x"] + 0.5), int($box["y"] + 0.5), int($box["width"] + 0.5), int($box["height"] + 0.5))
+    RETURN    ${annotation}

--- a/atest/test/02_Content_Keywords/aria_snapshot.robot
+++ b/atest/test/02_Content_Keywords/aria_snapshot.robot
@@ -56,6 +56,8 @@ Aria Snapshot Invalid Depth
             Get Aria Snapshot    ${MouseTable}    depth=${depth}
         EXCEPT    ValueError: depth must be a positive integer, but got: ${depth}
             Log    Failed as expected with depth ${depth}.
+        ELSE
+            Fail    Get Aria Snapshot did not reject depth ${depth}.
         END
     END
 
@@ -86,6 +88,8 @@ Aria Snapshot AI Mode Non-existing Element
         Get Aria Snapshot    id=non_existing_element    mode=ai
     EXCEPT    *does not match any element*    type=glob
         Log    Caught expected PlaywrightError without waiting for a timeout.
+    ELSE
+        Fail    Get Aria Snapshot returned a snapshot for a non-existing element in ai mode.
     END
 
 Aria Snapshot Options With Dict Return Type

--- a/atest/test/02_Content_Keywords/aria_snapshot.robot
+++ b/atest/test/02_Content_Keywords/aria_snapshot.robot
@@ -98,6 +98,44 @@ Aria Snapshot Options With Dict Return Type
     ${snapshot} =    Get Aria Snapshot    h1    dict    boxes=True
     Should Be Equal    ${snapshot}    ${expected}
 
+Aria Snapshot Parsed
+    ${nodes} =    Get Aria Snapshot    h1    parsed
+    Length Should Be    ${nodes}    1
+    Should Be Equal    ${nodes}[0][role]    heading
+    Should Be Equal    ${nodes}[0][name]    Login Page
+    Should Be Equal    ${nodes}[0][props][level]    ${1}
+    Should Be Equal    ${nodes}[0][text]    ${None}
+    Should Be Empty    ${nodes}[0][children]
+
+Aria Snapshot Parsed Nests Children
+    ${nodes} =    Get Aria Snapshot    ${MouseTable}    parsed
+    ${rowgroup} =    Set Variable    ${nodes}[0][children][0]
+    ${first_cell} =    Set Variable    ${rowgroup}[children][0][children][0]
+    Should Be Equal    ${nodes}[0][role]    table
+    Should Be Equal    ${rowgroup}[role]    rowgroup
+    Should Be Equal    ${first_cell}[role]    cell
+    Should Be Equal    ${first_cell}[name]    Upload Result:
+
+Aria Snapshot Parsed With Boxes Matches Get BoundingBox
+    ${box} =    Get BoundingBox    h1    ALL
+    ${nodes} =    Get Aria Snapshot    h1    parsed    boxes=True
+    ${rounded} =    Evaluate    {key: int(value + 0.5) for key, value in $box.items()}
+    Should Be Equal    ${nodes}[0][props][box]    ${rounded}
+
+Aria Snapshot Parsed With AI Mode Has Refs
+    ${nodes} =    Get Aria Snapshot    h1    parsed    mode=ai
+    Should Match Regexp    ${nodes}[0][props][ref]    ^\\w+$
+
+Aria Snapshot Parsed Reads Link Url As Property
+    ${nodes} =    Get Aria Snapshot    css=a >> nth=0    parsed
+    Should Be Equal    ${nodes}[0][role]    link
+    Should Be Equal    ${nodes}[0][props][url]    index.js
+    Should Be Empty    ${nodes}[0][children]
+
+Aria Snapshot Parsed Reads Valueless Annotation As True
+    ${nodes} =    Get Aria Snapshot    css=select    parsed
+    Should Be Equal    ${nodes}[0][children][0][props][selected]    ${True}
+
 *** Keywords ***
 Aria Snapshot Setup
     Ensure Open Page    ${LOGIN_URL}

--- a/node/playwright-wrapper/getters.ts
+++ b/node/playwright-wrapper/getters.ts
@@ -22,15 +22,32 @@ import { exists, findLocator } from './playwright-invoke';
 import { PlaywrightState } from './playwright-state';
 import { boolResponse, intResponse, jsonResponse, listStringResponse, stringResponse } from './response-util';
 
+type AriaSnapshotOptions = NonNullable<Parameters<Locator['ariaSnapshot']>[0]>;
+
+function ariaSnapshotOptions(request: pb.Request_AriaSnapShot): AriaSnapshotOptions {
+    const options: AriaSnapshotOptions = {};
+    if (request.mode) {
+        options.mode = request.mode as AriaSnapshotOptions['mode'];
+    }
+    if (request.depth > 0) {
+        options.depth = request.depth;
+    }
+    if (request.boxes) {
+        options.boxes = true;
+    }
+    return options;
+}
+
 export async function getAriaSnapshot(
     request: pb.Request_AriaSnapShot,
     state: PlaywrightState,
 ): Promise<pb.Response_String> {
     const selector = request.locator;
     const strictMode = request.strict;
+    const options = ariaSnapshotOptions(request);
     const locator = await findLocator(state, selector, strictMode, true);
-    const snapshot = await locator.ariaSnapshot();
-    logger.info(`Aria snapshot for ${selector}: ${snapshot}`);
+    const snapshot = await locator.ariaSnapshot(options);
+    logger.info(`Aria snapshot for ${selector} with options ${JSON.stringify(options)}: ${snapshot}`);
     return stringResponse(snapshot, 'Aria snapshot received successfully.');
 }
 

--- a/protobuf/playwright.proto
+++ b/protobuf/playwright.proto
@@ -20,6 +20,9 @@ message Request {
   message AriaSnapShot {
     string locator = 1;
     bool strict = 2;
+    string mode = 3;
+    int32 depth = 4;
+    bool boxes = 5;
   }
 
   message ClosePage {

--- a/utest/test_aria_snapshot_parser.py
+++ b/utest/test_aria_snapshot_parser.py
@@ -1,0 +1,185 @@
+import pytest
+
+from Browser.utils.aria_snapshot import parse_aria_snapshot
+
+
+def test_empty_snapshot():
+    assert parse_aria_snapshot("") == []
+
+
+def test_blank_snapshot():
+    assert parse_aria_snapshot("\n") == []
+
+
+def test_unknown_label_syntax_survives_as_role():
+    [node] = parse_aria_snapshot("- some future syntax")
+    assert node.role == "some future syntax"
+    assert node.props == {}
+    assert node.children == []
+
+
+def test_role_only():
+    [node] = parse_aria_snapshot("- button")
+    assert node.role == "button"
+    assert node.name is None
+    assert node.text is None
+    assert node.props == {}
+    assert node.children == []
+
+
+def test_role_and_name():
+    [node] = parse_aria_snapshot('- textbox "User Name:"')
+    assert node.role == "textbox"
+    assert node.name == "User Name:"
+
+
+def test_name_with_apostrophe():
+    [node] = parse_aria_snapshot('- button "Doesn\'t do anything"')
+    assert node.name == "Doesn't do anything"
+
+
+def test_name_with_escaped_quotes():
+    [node] = parse_aria_snapshot('- heading "He said \\"hi\\""')
+    assert node.name == 'He said "hi"'
+
+
+def test_numeric_property_is_int():
+    [node] = parse_aria_snapshot('- heading "Login Page" [level=1]')
+    assert node.props.level == 1
+
+
+def test_property_without_value_is_true():
+    [node] = parse_aria_snapshot('- option "Dog" [selected]')
+    assert node.props.selected is True
+
+
+def test_string_properties():
+    [node] = parse_aria_snapshot("- link [ref=e74] [cursor=pointer] [checked=mixed]")
+    assert node.props.ref == "e74"
+    assert node.props.cursor == "pointer"
+    assert node.props.checked == "mixed"
+
+
+def test_box_property_matches_get_boundingbox_keys():
+    [node] = parse_aria_snapshot("- heading [box=8,21,1264,37]")
+    assert node.props.box == {"x": 8, "y": 21, "width": 1264, "height": 37}
+
+
+def test_all_properties_of_one_node():
+    [node] = parse_aria_snapshot(
+        '- heading "Login Page" [level=1] [ref=e3] [box=8,21,1264,37]'
+    )
+    assert node.role == "heading"
+    assert node.name == "Login Page"
+    assert node.props == {
+        "level": 1,
+        "ref": "e3",
+        "box": {"x": 8, "y": 21, "width": 1264, "height": 37},
+    }
+
+
+def test_scalar_content_becomes_text():
+    [node] = parse_aria_snapshot("- generic [ref=e29]: Online")
+    assert node.text == "Online"
+    assert node.children == []
+
+
+def test_text_role_carries_its_content():
+    [node] = parse_aria_snapshot('- text: "Choose a pet:"')
+    assert node.role == "text"
+    assert node.name is None
+    assert node.text == "Choose a pet:"
+
+
+def test_named_node_can_have_text():
+    [node] = parse_aria_snapshot('- paragraph "Intro": Please input your user name.')
+    assert node.name == "Intro"
+    assert node.text == "Please input your user name."
+
+
+def test_children_are_nested():
+    snapshot = "\n".join(
+        [
+            "- table:",
+            "  - rowgroup:",
+            "    - row:",
+            '      - cell "User Name:"',
+        ]
+    )
+    [table] = parse_aria_snapshot(snapshot)
+    assert table.role == "table"
+    [rowgroup] = table.children
+    [row] = rowgroup.children
+    [cell] = row.children
+    assert cell.role == "cell"
+    assert cell.name == "User Name:"
+    assert cell.children == []
+
+
+def test_node_without_children_after_colon():
+    [node] = parse_aria_snapshot("- listitem:")
+    assert node.role == "listitem"
+    assert node.text is None
+    assert node.children == []
+
+
+def test_url_of_link_becomes_property_of_the_link():
+    snapshot = '- link "Download file":\n  - /url: index.js'
+    [link] = parse_aria_snapshot(snapshot)
+    assert link.props.url == "index.js"
+    assert link.children == []
+
+
+def test_siblings_with_identical_labels_are_kept():
+    label = '- button "Doesn\'t do anything"'
+    nodes = parse_aria_snapshot("\n".join([label, label, label]))
+    assert [node.name for node in nodes] == ["Doesn't do anything"] * 3
+
+
+def test_top_level_can_hold_several_nodes():
+    nodes = parse_aria_snapshot("- iframe\n- iframe")
+    assert [node.role for node in nodes] == ["iframe", "iframe"]
+
+
+def test_dot_access_works_on_nested_nodes():
+    snapshot = '- generic [ref=e1]:\n  - textbox "username" [ref=e10]'
+    [generic] = parse_aria_snapshot(snapshot)
+    assert generic.children[0].props.ref == "e10"
+
+
+@pytest.fixture
+def login_form():
+    return "\n".join(
+        [
+            "- generic [ref=e1] [box=506,0,253,279]:",
+            '  - heading "Login" [level=2] [ref=e3] [box=506,0,253,32]',
+            "  - generic [ref=e4] [box=516,56,233,66]:",
+            '    - textbox "username" [ref=e10] [box=553,76,186,18]',
+            "    - generic [box=553,56,186,46]: username",
+            '  - button "login" [ref=e19] [cursor=pointer] [box=516,207,233,36]',
+            "  - generic [ref=e21] [box=603,243,60,36]:",
+            "    - checkbox [box=633,260,0,0]",
+        ]
+    )
+
+
+def test_login_form_structure(login_form):
+    [root] = parse_aria_snapshot(login_form)
+    assert root.role == "generic"
+    assert [child.role for child in root.children] == [
+        "heading",
+        "generic",
+        "button",
+        "generic",
+    ]
+
+
+def test_login_form_leaf_details(login_form):
+    [root] = parse_aria_snapshot(login_form)
+    username_group = root.children[1]
+    textbox, label = username_group.children
+    assert textbox.role == "textbox"
+    assert textbox.name == "username"
+    assert textbox.props.box == {"x": 553, "y": 76, "width": 186, "height": 18}
+    assert label.text == "username"
+    assert root.children[3].children[0].role == "checkbox"


### PR DESCRIPTION
Get Aria Snapshot now exposes the three options that locator.ariaSnapshot() already offers in the pinned Playwright version:

- mode=ai returns the snapshot optimized for AI consumption, with [ref=...] annotations and the content of iframes inside the element. It does not wait for a matching element and fails immediately when none matches.
- depth limits the snapshot to the given number of tree levels.
- boxes appends [box=x,y,width,height] to every node.

All three are named-only arguments and their defaults reproduce the previous output unchanged.