### PR TITLE
Close the rfbrowser CLI coverage gaps (ticket 0011)

### DIFF
--- a/.github/scripts/verify_clean_node.py
+++ b/.github/scripts/verify_clean_node.py
@@ -1,0 +1,55 @@
+"""Verify that ``rfbrowser clean-node`` actually removed the node dependencies.
+
+CI runs ``rfbrowser clean-node`` as the last step before uninstalling the library,
+so nothing after it observes anything except its exit code -- and the command
+returns 0 whether it deleted the dependencies or merely found nothing to delete.
+This asserts the result instead.
+
+Run it *after* ``rfbrowser clean-node`` and *before* ``pip uninstall``: it locates
+the installed package, and once pip has removed it there is nothing left to check.
+
+Deliberately a script file rather than an inline ``python -c``. It reads the same
+in bash and PowerShell, and because ``sys.path[0]`` is this file's directory rather
+than the working directory, a ``Browser/`` source tree in the checkout cannot
+shadow the installed package and send the check at the wrong directory.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+MAX_LISTED_LEFTOVERS = 10
+
+
+def installed_node_modules() -> Path:
+    """The node_modules directory belonging to the *installed* Browser package.
+
+    Mirrors ``NODE_MODULES`` in ``Browser/entry/constant.py``, which is what
+    ``clean-node`` deletes. Resolved without importing Browser, so this still works
+    if the node side is already gone.
+    """
+    spec = importlib.util.find_spec("Browser")
+    if spec is None or spec.origin is None:
+        sys.exit(
+            "Browser is not installed, so there is nothing to verify. "
+            "Run this after 'rfbrowser clean-node' but before 'pip uninstall'."
+        )
+    return Path(spec.origin).parent / "wrapper" / "node_modules"
+
+
+def main() -> int:
+    node_modules = installed_node_modules()
+    print(f"Checking {node_modules}")
+    if node_modules.exists():
+        leftovers = sorted(path.name for path in node_modules.iterdir())
+        shown = ", ".join(leftovers[:MAX_LISTED_LEFTOVERS])
+        sys.exit(
+            f"rfbrowser clean-node exited 0 but {node_modules} is still present "
+            f"with {len(leftovers)} entries: {shown}"
+        )
+    print("OK: rfbrowser clean-node removed the node dependencies.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -352,6 +352,7 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
           rfbrowser clean-node
+          python .github/scripts/verify_clean_node.py
           uv pip uninstall robotframework-browser  --python ${{ matrix.python-version }} --system
       - uses: actions/upload-artifact@v7
         if: ${{ always() }}
@@ -535,6 +536,7 @@ jobs:
       - name: Uninstall
         run: |
           rfbrowser clean-node
+          python .github/scripts/verify_clean_node.py
           pip uninstall -y robotframework-browser-batteries
           pip uninstall -y robotframework-browser
 

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -219,6 +219,7 @@ jobs:
       - name: Uninstall
         run: |
           rfbrowser clean-node
+          python .github/scripts/verify_clean_node.py
           pip uninstall -y robotframework-browser-batteries
           pip uninstall -y robotframework-browser
 

--- a/Browser/entry/__main__.py
+++ b/Browser/entry/__main__.py
@@ -483,9 +483,12 @@ def convert_options_types(options: list[str], browser_lib: "Browser"):
             raise RuntimeError(
                 f"Invalid argument name {key}. Argument names must be one of {', '.join(keyword_types.keys())}"
             )
-        params[key] = RobotTypeConverter.converter_for(keyword_types[key]).convert(
-            name=key, value=value
-        )
+        if (converter := RobotTypeConverter.converter_for(keyword_types[key])) is None:
+            raise RuntimeError(
+                f"Invalid option {key}. Argument type {keyword_types[key]} can not be "
+                f"converted by this Robot Framework version."
+            )
+        params[key] = converter.convert(name=key, value=value)
     return params
 
 

--- a/atest/library/os_wrapper.py
+++ b/atest/library/os_wrapper.py
@@ -60,11 +60,21 @@ def glob_files_count(path: str) -> int:
     return len(glob_files(path))
 
 
+def get_enty_command_list() -> list[str]:
+    """Return correct entry point command as argv, for subprocess without a shell.
+
+    Never pass this list to subprocess with ``shell=True``: on POSIX that runs only
+    the first element and silently drops the rest. Use `Get Enty Command` for the
+    string form that `Run Process    shell=True` needs.
+    """
+    if bool(int(os.environ.get("SYS_VAR_CI_INSTALL_TEST", "0"))):
+        return ["rfbrowser"]
+    return [sys.executable, "-m", "Browser.entry"]
+
+
 def get_enty_command() -> str:
     """Return correct entry point command."""
-    if bool(int(os.environ.get("SYS_VAR_CI_INSTALL_TEST", 0))):
-        return "rfbrowser"
-    return f"{sys.executable} -m Browser.entry"
+    return " ".join(get_enty_command_list())
 
 
 def get_robot_command() -> str:

--- a/atest/library/show_trace_tool.py
+++ b/atest/library/show_trace_tool.py
@@ -1,59 +1,113 @@
+"""Helpers for checking the ``rfbrowser show-trace`` command.
+
+These used to pass a list to ``subprocess.Popen`` together with ``shell=True``.
+On POSIX that runs ``/bin/sh -c <first element>`` and drops every remaining
+argument, so ``rfbrowser`` was started with no arguments at all: the help check
+asserted against the top level command group rather than ``show-trace``, and no
+trace viewer was ever started. The processes are now started without a shell so
+the arguments reach the command.
+"""
+
+import contextlib
 import subprocess
 import time
 from pathlib import Path
 
 import psutil
+from os_wrapper import get_enty_command_list
 from psutil import NoSuchProcess
 from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
 
+HELP_TIMEOUT = 30
+VIEWER_START_DELAY = 3
+VIEWER_WAIT = 60
+VIEWER_STOP_TIMEOUT = 10
 
-def run_rfbrowser_help():
+# The viewer is a long running process started outside Robot Framework's Process
+# library, so `Terminate All Processes` does not know about it. Every started
+# viewer is tracked here so `Stop Show Trace` can end it even when the test that
+# started it failed before it got a handle back.
+_started_viewers: list[subprocess.Popen] = []
+
+
+def run_rfbrowser_show_trace_help() -> str:
+    """Return the output of ``rfbrowser show-trace --help``."""
     exec_dir = BuiltIn().get_variable_value("${EXECDIR}")
-    ouput_dir = BuiltIn().get_variable_value("${OUTPUT_DIR}")
-    out_file = Path(ouput_dir, "rfbrower_2.log")
-    with open(out_file, "w") as file:
-        process = subprocess.Popen(
-            ["rfbrowser", "show-trace", "--help"],
-            cwd=exec_dir,
-            stderr=subprocess.STDOUT,
-            stdout=file,
-            shell=True,
+    command = [*get_enty_command_list(), "show-trace", "--help"]
+    logger.info(f"Running: {command}")
+    process = subprocess.run(
+        command,
+        cwd=exec_dir,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=HELP_TIMEOUT,
+        check=False,
+        text=True,
+    )
+    logger.info(process.stdout)
+    if process.returncode != 0:
+        raise AssertionError(
+            f"show-trace --help exited with {process.returncode}:\n{process.stdout}"
         )
-    time.sleep(2)
-    help_text = out_file.read_text()
-    logger.info(help_text)
-    try:
-        process.wait(timeout=5)
-    except subprocess.TimeoutExpired:
-        process.kill()
-        raise
-    return help_text
+    return process.stdout
 
 
-def start_show_trace(zip_file: str):
+def start_show_trace(zip_file: str) -> tuple[subprocess.Popen, Path]:
     zip_file = Path(zip_file).resolve(strict=True)
     exec_dir = BuiltIn().get_variable_value("${EXECDIR}")
     ouput_dir = BuiltIn().get_variable_value("${OUTPUT_DIR}")
     out_file = Path(ouput_dir, "rfbrower_1.log")
+    # The trace file is a positional argument. An earlier version of this helper
+    # passed it as "-F", which show-trace has no such option for -- it never
+    # surfaced because the shell=True bug meant the arguments were dropped anyway.
+    command = [*get_enty_command_list(), "show-trace", str(zip_file)]
+    logger.info(f"Running: {command}")
     with open(out_file, "w") as file:
         process = subprocess.Popen(
-            ["rfbrowser", "show-trace", "-F", str(zip_file)],
+            command,
             cwd=exec_dir,
             stderr=subprocess.STDOUT,
             stdout=file,
-            shell=True,
         )
+    _started_viewers.append(process)
     logger.info("Give process time to start")
-    time.sleep(3)
+    time.sleep(VIEWER_START_DELAY)
     logger.info(f"Trace viewer output: {out_file.read_text()}")
-    assert process.returncode is None, (
-        "Process should be still running, but it was not."
-    )
+    if process.poll() is not None:
+        raise AssertionError(
+            f"show-trace exited with {process.returncode} instead of staying up:\n"
+            f"{out_file.read_text()}"
+        )
     return process, out_file
 
 
-def _check_trace_process(process: subprocess.Popen, out_file: Path):
+def stop_show_trace() -> None:
+    """Terminate every trace viewer started in this suite, and its children.
+
+    The viewer spawns npm, node and a chromium browser. Killing only the process
+    that `Start Show Trace` returned leaves those running and reparented to init,
+    so the whole tree is taken down.
+    """
+    while _started_viewers:
+        parent = _started_viewers.pop()
+        try:
+            handle = psutil.Process(parent.pid)
+        except NoSuchProcess:
+            continue
+        processes = handle.children(recursive=True)
+        processes.append(handle)
+        logger.info(f"Stopping trace viewer tree: {[p.pid for p in processes]}")
+        for process in processes:
+            with contextlib.suppress(NoSuchProcess):
+                process.terminate()
+        _, alive = psutil.wait_procs(processes, timeout=VIEWER_STOP_TIMEOUT)
+        for process in alive:
+            with contextlib.suppress(NoSuchProcess):
+                process.kill()
+
+
+def _check_trace_process(process: subprocess.Popen, out_file: Path) -> bool:
     pid = process.pid
     try:
         psutil.pid_exists(pid)
@@ -63,19 +117,16 @@ def _check_trace_process(process: subprocess.Popen, out_file: Path):
     proc = psutil.Process(pid)
     binary = False
     show_trace = False
-    file_arg = False
     trace_zip = False
     for cmd in proc.cmdline():
         logger.info(f"cmd: {cmd}")
-        if "rfbrowser" in cmd:
+        if "rfbrowser" in cmd or "Browser.entry" in cmd:
             binary = True
         if "show-trace" in cmd:
             show_trace = True
-        if "-F" in cmd:
-            file_arg = True
         if "trace_1.zip" in cmd:
             trace_zip = True
-    if binary and show_trace and file_arg and trace_zip:
+    if binary and show_trace and trace_zip:
         logger.info("Main process found, check child process")
         node = False
         chromium = False
@@ -101,10 +152,10 @@ def _check_trace_process(process: subprocess.Popen, out_file: Path):
     return False
 
 
-def check_trace_process(prcess: subprocess.Popen, out_file: Path):
-    end_time = time.monotonic() + 60
+def check_trace_process(process: subprocess.Popen, out_file: Path) -> bool:
+    end_time = time.monotonic() + VIEWER_WAIT
     while end_time > time.monotonic():
-        if _check_trace_process(prcess, out_file):
+        if _check_trace_process(process, out_file):
             return True
         logger.info("Sleep 1s and retry.")
         logger.info(f"Trace file output: {out_file.read_text()}")

--- a/atest/test/01_Browser_Management/tracing.robot
+++ b/atest/test/01_Browser_Management/tracing.robot
@@ -45,17 +45,19 @@ Enable Tracing To File With Two Browsers
     File Should Not Be Empty    ${OUTPUT_DIR}/trace_1.zip
     File Should Not Be Empty    ${OUTPUT_DIR}/trace_2.zip
 
+Check Show-Trace Command Help
+    [Timeout]    60s
+    ${help} =    Run Rfbrowser Show Trace Help
+    Should Contain    ${help}    Start the Playwright trace viewer.
+    Should Contain    ${help}    --stdin
+    Should Contain    ${help}    show-trace [OPTIONS] [FILE]
+
 Check Show-Trace Command
-    [Tags]    no-windows-support    # Is not stable in Windows
+    [Tags]    slow    no-windows-support    # slow: needs trace_1.zip from the test above
     [Timeout]    90s
-    IF    '${SYS_VAR_CI}' == 'False'
-        Log    This is only for CI when installation is done.
-    ELSE
-        ${help} =    Run Rfbrowser Help
-        Should Contain    ${help}    Possible commands are
-        ${process}    ${procss_stdout_file} =    Start Show Trace    ${OUTPUT_DIR}/trace_1.zip
-        Check Trace Process    ${process}    ${procss_stdout_file}
-    END
+    ${process}    ${procss_stdout_file} =    Start Show Trace    ${OUTPUT_DIR}/trace_1.zip
+    Check Trace Process    ${process}    ${procss_stdout_file}
+    [Teardown]    Stop Show Trace
 
 Tracing And Closing All Browsers
     [Tags]    slow

--- a/atest/test/variables.resource
+++ b/atest/test/variables.resource
@@ -44,7 +44,6 @@ ${WEBCOMPONENT_PAGE} =                  ${ROOT_URL}webcomponent.html
 ${LINKER_URL} =                         ${ROOT_URL}links/link1.html
 ${SPACES_URL} =                         ${ROOT_URL}spaces.html
 ${TABLES_URL} =                         ${ROOT_URL}tables.html
-${SYS_VAR_CI} =                         False
 ${SYS_VAR_CLEAN} =                      ${True}
 ${NETWORK_IDLE_FILE_DATA} =             ${EMPTY}
 ${INPUT_ELEMENT_COUNT_IN_LOGIN} =       5

--- a/docs/research/rfbrowser-cli-coverage.md
+++ b/docs/research/rfbrowser-cli-coverage.md
@@ -1,0 +1,238 @@
+# `rfbrowser` CLI — what is verified, and what is deliberately not
+
+> **An evidence record, not documentation. Documentation lives on robotframework-browser.org.**
+>
+> This file records which `rfbrowser` commands have their *results* checked, which are covered
+> only indirectly, and which are deliberately left to a human — with the reason written down
+> rather than inferred from a missing test. It is kept in this repository because its claims are
+> claims about the tests here.
+>
+> **Point-in-time record, 2026-08-19.** Measured against Browser 20.4.0, Robot Framework 7.4.1,
+> Python 3.14.7, macOS. Ticket 0011.
+>
+> **Two markers are used and they mean different things.**
+>
+> - **[M] measured** — proven by a named test that was run green on the date above.
+> - **[R] read** — verified against source at a named line, never executed.
+>
+> The distinction earns its place here: ticket 0011 arrived with an inventory that had been read
+> rather than run, and it was wrong about four of its nine rows. §2 records what it got wrong,
+> because the *way* it was wrong is the thing worth remembering.
+
+## 1. The inventory
+
+| command | how it is exercised | result verified | decision |
+| --- | --- | --- | --- |
+| `init` | `on-push.yml:332`, setup for the clean-install job | indirectly — the atest run that follows would fail | **accept**: indirect coverage is sufficient |
+| `install` | `on-push.yml:490,498`, `on-release.yml:173,181` | indirectly, same | **accept**: indirect coverage is sufficient |
+| `launch-browser-server` | atest `Launch Browser Server Via CLI`, `… With Proxy` (`playwright_state.robot:445,487`) | **[M] directly** | **automated**; Ctrl-C path manual, see §4 |
+| `show-trace` | atest `Check Show-Trace Command Help`, `Check Show-Trace Command` (`tracing.robot:48,61`) | **[M] directly** | **automated** — newly, see §3 |
+| `clean-node` | `on-push.yml:354,538`, `on-release.yml:221` | **[M] asserted after the fact**, see §5 | **assert after the fact** |
+| `uninstall` | nowhere end to end | **[M] delegation only**, `utest/test_entry_uninstall.py` | **accept as manual**, see §6 |
+| `transform` | atest `Tranform Wait Until Network Is Idle Keyword` (`11_tidy_transformer/network_idle_test.robot`) | **[M] directly** — asserts the rewritten file line by line | **automated**, no work needed |
+| `translation` | atest `12_rfbrowser/translation.robot`, 5 cases | **[M] directly** — incl. `--plugings`, `--jsextension`, `--compare` | **automated**, no work needed |
+| `coverage` | atest `01_Browser_Management/coverage.robot`, 6 cases | **[M] directly** — 3 happy paths, 3 error paths (rc 1 and 2) | **automated**, no work needed |
+
+Command definitions in `Browser/entry/__main__.py`: `init:207`, `clean_node:253`, `show_trace:324`,
+`launch_browser_server:391`, `install:502`, `uninstall:542`, `transform:573`, `translation:618`,
+`coverage:688`.
+
+## 2. What ticket 0011's inventory got wrong
+
+Recorded because the error has a pattern, not to relitigate the ticket. Four of nine rows:
+
+- **`transform`, `translation` and `coverage` were listed as run "nowhere".** All three have
+  direct acceptance coverage, and `coverage` has the most thorough coverage of any command in
+  the CLI. A grep for the command names would have found them; the inventory appears to have
+  been assembled from the workflow files alone, which is where the *installation* commands live.
+- **`show-trace` was listed as verified "directly — help output plus the viewer process".** It
+  was verified neither way. See §3.
+
+The inventory also asserted that the workflows use `pip uninstall` "instead of" `rfbrowser
+uninstall`. They are not substitutes: `rfbrowser uninstall` runs `npx playwright uninstall` to
+remove browser *binaries*, `pip uninstall` removes the Python *package*. The workflows pair
+`rfbrowser clean-node` with `pip uninstall`, which is exactly the sequence `__main__.py:150-154`
+tells users to follow. **[R]**
+
+## 3. `show-trace` — was covered three ways over, none of them real
+
+Before ticket 0011 this command had a test that could not fail. Three independent reasons, each
+sufficient on its own:
+
+1. **It never ran.** `tracing.robot` gated the body on `IF '${SYS_VAR_CI}' == 'False'` and logged
+   a message otherwise. `${SYS_VAR_CI}` is the literal `False` (`atest/test/variables.resource:47`)
+   and is set to `True` only by `inv atest-global-pythonpath` (`tasks.py:1158`) — **which no
+   workflow invokes**. CI runs `inv atest` and `invoke atest-robot`, which set
+   `SYS_VAR_CI_INSTALL_TEST`, a different variable. **[M]**
+2. **The helpers dropped their arguments.** All three functions in
+   `atest/library/show_trace_tool.py` passed a *list* to `subprocess.Popen` together with
+   `shell=True`. On POSIX that runs `/bin/sh -c <first element>` and every remaining element
+   becomes a shell positional parameter, so `rfbrowser` was started with no arguments. Measured:
+
+   ```
+   shell=True  -> rfbrowser received argv:
+   shell=False -> rfbrowser received argv: show-trace --help
+   ```
+
+   The help check therefore asserted `Should Contain ${help} Possible commands are` against bare
+   `rfbrowser`, and that string is in the top-level group docstring (`__main__.py:114`), not in
+   `show_trace`, whose help reads "Start the Playwright trace viewer." The assertion passed
+   without the command under test being involved. **[M]**
+3. **The viewer was started with an option that does not exist.** The helper passed the trace as
+   `-F <file>`; `show_trace` takes it as a positional argument and has no `-F`. Running the
+   fixed helper surfaced `Error: No such option '-F'` immediately — which is also proof that the
+   command had never once been executed by this test. **[M]**
+
+**What changed.** The helpers now run without a shell and resolve the entry point the same way
+the rest of atest does (`rfbrowser` when `SYS_VAR_CI_INSTALL_TEST` is set, `python -m
+Browser.entry` otherwise). That removed the *reason* for the gate — its own message,
+"This is only for CI when installation is done", described the hardcoded `rfbrowser` console
+script — so the gate is gone and both checks run in every atest run. The check is split in two:
+
+- **`Check Show-Trace Command Help`** — asserts against `show-trace`'s own help. Pure text: it
+  needs no display, no installed console script and no trace file, so it carries no tags and runs
+  on every platform in every run.
+- **`Check Show-Trace Command`** — starts a real viewer and asserts the node and chromium child
+  processes come up. Keeps `no-windows-support`, which predates this work, and is tagged **`slow`**
+  — see below.
+
+Both were run green ungated on macOS; the whole `Tracing` suite passes in 7.7 s. **[M] If the
+viewer check proves flaky on a runner, the fix is a tag with the reason written here — not a
+condition that makes it pass by not running.**
+
+**The viewer must be torn down.** `Start Show Trace` launches the viewer with
+`subprocess.Popen`, outside Robot Framework's Process library, so `Terminate All Processes` does
+not know about it — and the original test had no teardown at all. That was harmless only while the
+test never ran; ungating it leaked a viewer plus its npm, node and chromium children on every run,
+reparented to init. `Stop Show Trace` now takes down the whole process tree, and the helper tracks
+what it started so teardown works even when the test failed before getting a handle back. Verified
+both ways: no processes survive a passing run or a failing one. **[M]**
+
+**The `slow` tag is load-bearing, not a performance note.** The viewer check consumes
+`${OUTPUT_DIR}/trace_1.zip`, which only `Enable Tracing To File With Two Browsers` produces, and
+that test is `[Tags] slow`. `invoke atest-robot --smoke` adds `--exclude slow` (`tasks.py:1120`)
+and two CI jobs run exactly that (`on-push.yml:343,521`). Ungating the test without inheriting the
+tag left it running in smoke jobs with its input never created, failing on
+`Path(zip_file).resolve(strict=True)` — reproduced, two jobs would have gone red. **[M]** Tagging
+it `slow` keeps producer and consumer excluded together. Anything that later gives this test its
+own trace file can drop the tag.
+
+**`${SYS_VAR_CI}` is gone.** Removing the gate left it with no reader, so the variable
+(`atest/test/variables.resource`) and `inv atest-global-pythonpath`'s `--variable SYS_VAR_CI:True`
+(`tasks.py:1158`) were both deleted. The task itself stays; it is about the global pythonpath, not
+about this variable.
+
+**Why `robotstatuschecker` matters here.** An intermediate version of this work used `Skip If`
+instead of deleting the gate. `robotstatuschecker` failed the run — *"Expected PASS status, got
+SKIP"* — because a skip is only allowed when the test documentation declares it. The repository
+already refuses silent skips; that tooling is the reason this class of bug is worth hunting
+rather than assuming. **[M]**
+
+## 4. `launch-browser-server` — covered, with one documented hole
+
+`Launch Browser Server Via CLI` and `Launch Browser Server Via CLI With Proxy`
+(`playwright_state.robot:445,487`) start the real command with `Start Process` and *separate
+arguments*, so the shell bug in §3 never applied to them. The proxy case points the server at a
+dead proxy on port 1 and requires `net::ERR_PROXY_CONNECTION_FAILED`, so the option provably
+reaches the browser rather than being accepted and ignored. **[M]**
+
+**Accepted as manual:** the `KeyboardInterrupt` branch (`__main__.py:459`). The acceptance
+test tears the server down with `Terminate All Processes`, i.e. SIGTERM, so the Ctrl-C path is
+never entered in CI. Hand-checked under ticket 0005.
+
+## 5. `clean-node` — asserted after the fact
+
+The command runs in CI three times and always as the last step before uninstalling, so nothing
+observed anything but its exit code — and it exits 0 whether it deleted the dependencies or found
+nothing to delete. Two additions:
+
+- **`.github/scripts/verify_clean_node.py`**, run immediately after `rfbrowser clean-node` and
+  before `pip uninstall` at all three sites (`on-push.yml:355,539`, `on-release.yml:222`). It
+  locates the *installed* package with `importlib.util.find_spec` and fails if
+  `wrapper/node_modules` survives. Both branches were exercised locally. **[M]**
+- **`utest/test_clean_node.py`**, which pins the deletion semantics against a stand-in
+  installation directory, including two things worth knowing:
+  - browser binaries go with the dependencies **because they live inside them** —
+    `get_playwright_browser_path()` returns `node_modules/playwright-core/.local-browsers` when
+    `PLAYWRIGHT_BROWSERS_PATH` is unset. `clean_node` does not remove them separately, so if that
+    default ever moves outside `node_modules` the command needs a second deletion; the test goes
+    red if it does. **[M]**
+  - browsers installed **outside** the default location survive `clean-node`. That is a
+    documented limit, matching the command's "from the library default installation location"
+    wording — not a defect. A user who set `PLAYWRIGHT_BROWSERS_PATH` removes them themselves.
+    **[M]**
+
+The utests were mutation-checked: removing the `shutil.rmtree` call turns three of them red. **[M]**
+
+## 6. `uninstall` — accepted as manual, with the delegation automated
+
+**It cannot run end to end on a runner.** `npx playwright uninstall` removes the shared browser
+binaries, which every test after it in the same job needs. Running it for real would either break
+the job or require a dedicated one whose only purpose is to delete browsers and stop.
+
+What is automated instead, in `utest/test_entry_uninstall.py`: that the command delegates to
+`npx playwright uninstall`, that `--all` is forwarded, and that
+`ensure_playwright_browsers_path()` runs *before* the library is constructed — without which npx
+looks in Playwright's own default location rather than this installation's, and removes nothing.
+**[M]**
+
+**A side effect worth knowing about.** `ensure_playwright_browsers_path()`
+(`Browser/entry/constant.py:121`) writes `PLAYWRIGHT_BROWSERS_PATH` into `os.environ` and never
+removes it. Harmless for a one-shot CLI process, but it means the command cannot be invoked
+in-process without isolating that variable: an early version of
+`utest/test_entry_uninstall.py` did not, and it pointed the other 23 browser-backed unit tests
+at a browser directory that does not exist. The fixture stubs it for that reason. **[M]**
+
+One property pinned deliberately rather than fixed: the npx call is wrapped in
+`contextlib.suppress(Exception)` (`__main__.py:555`), so a failure to remove the binaries still
+exits 0 and reports nothing. **That is why the exit code alone was never evidence**, and why the
+test asserts on the delegation. Whether the suppression should stay is a separate question and
+was not opened here.
+
+## 7. Decision: `convert_options_types` keeps its conversion
+
+`launch-browser-server` converts its options twice — once in `convert_options_types`
+(`__main__.py:470`), once again when line 451 calls the keyword by attribute access and ticket
+0003's proxy converts them a second time. Conversion is idempotent and this is safe. The question
+raised in the 0003 review was whether the first conversion still earns its place.
+
+**Decision: keep it.** Maintainer's call, 2026-08-19. Three reasons:
+
+1. **The error contract stays in one style.** The function's two failure modes both report as a
+   `RuntimeError` naming the *CLI option*. Dropping the conversion moves bad *values* onto Robot
+   Framework's `ValueError`, which names the *keyword argument* instead, while bad *names* keep
+   the old wording — two failure modes, two vocabularies, for one command.
+2. **The lookup is already paid for.** Key validation has to stay whatever happens, and it
+   already calls `get_keyword_types`. The conversion on top of it is nearly free.
+3. **It keeps the CLI self-sufficient.** Deleting it would make the command's correctness depend
+   on the `attributes` proxy, which rests on a PythonLibCore internal (ADR 0006). Six explicit
+   lines are cheaper than that coupling.
+
+`utest/test_convert_options_types.py` now pins the contract — it did not exist before, despite
+both ticket 0011 and the handoff stating that it did. **If the conversion is ever dropped, the
+two error-shape tests in that file are the ones to rewrite, and the argument belongs there.**
+
+**Also fixed:** `converter_for(...)` was called with `.convert` chained directly onto it, with no
+`None` guard. On Robot Framework <= 7.2 an unconvertible option type returns `None` there and the
+user would get `AttributeError: 'NoneType' object has no attribute 'convert'`. It is now guarded
+and raises the same CLI-shaped `RuntimeError` as the neighbouring failures. **Not reachable
+today** — all 21 `launch_browser_server` option types convert on both supported Robot Framework
+versions, and `test_every_launch_browser_server_option_is_convertible` fails and names the option
+if that ever stops being true. **[M]**
+
+## 8. Standing rules this ticket leaves behind
+
+- **A command that runs as CI setup or teardown is not covered.** Its exit code is the only thing
+  observed, and `clean-node` and `uninstall` both exit 0 on doing nothing.
+- **Never gate a test on a condition that makes it log and pass.** Skip it, so it reports as
+  skipped, or delete the condition. `robotstatuschecker` enforces this as long as the test
+  actually reaches a skip.
+- **Never pass a list to `subprocess` with `shell=True`.** On POSIX every argument after the
+  first is silently dropped. `atest/library/os_wrapper.py:get_enty_command` returns a *string*
+  for keywords that use `Run Process    shell=True`; `show_trace_tool.py` keeps its own argv
+  *list* because it starts processes without a shell. Do not mix the two.
+- **A test that consumes another test's artifact must carry that test's exclusion tags.**
+  Otherwise a filtered run keeps the consumer and drops the producer, and the consumer fails on a
+  missing input rather than on the thing it tests.
+- **Verify an inventory before extending it.** Four of nine rows here were wrong, in the
+  direction of claiming more coverage than existed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,10 @@ select = [
 ".github/skills/parse-rf-results/scripts/parse_results.py" = [
     "T201",
 ]
+".github/scripts/verify_clean_node.py" = [
+    "T201",
+    "INP001",
+]
 
 [tool.robocop.format]
 line_ending = "unix"

--- a/tasks.py
+++ b/tasks.py
@@ -1155,8 +1155,7 @@ def atest_robot(c, smoke=False, suite=None, batteries=False):
 
 @task(clean_atest)
 def atest_global_pythonpath(c):
-    args = ["--variable", "SYS_VAR_CI:True"]
-    args.extend(_get_listener_args())
+    args = _get_listener_args()
     rc = _run_pabot(args)
     _clean_pabot_results(rc)
     sys.exit(rc)
@@ -1433,6 +1432,7 @@ def lint_python(c, fix=False):
         "utest",
         "browser_batteries",
         ".github/skills/",
+        ".github/scripts/",
     ]
     ruff_cmd_check = [
         "ruff",
@@ -1443,6 +1443,7 @@ def lint_python(c, fix=False):
         "browser_batteries/",
         "bootstrap.py",
         ".github/skills/",
+        ".github/scripts/",
     ]
     if fix:
         ruff_cmd_check.insert(2, "--fix")

--- a/utest/test_clean_node.py
+++ b/utest/test_clean_node.py
@@ -1,0 +1,81 @@
+import shutil
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from Browser.entry import __main__ as entry
+from Browser.entry.constant import PLAYWRIGHT_BROWSERS_PATH, get_playwright_browser_path
+
+
+@pytest.fixture(autouse=True)
+def quiet_info(monkeypatch: pytest.MonkeyPatch):
+    # clean-node shells out to pip freeze and npm -v before deleting anything.
+    monkeypatch.setattr(entry, "_python_info", lambda: None)
+    monkeypatch.setattr(entry, "_node_info", lambda: None)
+    monkeypatch.setattr(entry, "log_install_dir", lambda *args: None)
+
+
+@pytest.fixture
+def node_modules(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    node_modules = tmp_path / "wrapper" / "node_modules"
+    browsers = node_modules / "playwright-core" / ".local-browsers" / "chromium-1234"
+    browsers.mkdir(parents=True)
+    (browsers / "1").write_text("browser binary")
+    (node_modules / "some-dependency").mkdir()
+    (node_modules / "some-dependency" / "index.js").write_text("dependency")
+    monkeypatch.setattr(entry, "NODE_MODULES", node_modules)
+    monkeypatch.setattr("Browser.entry.constant.NODE_MODULES", node_modules)
+    return node_modules
+
+
+def test_deletes_the_node_dependencies(node_modules: Path):
+    result = CliRunner().invoke(entry.clean_node)
+
+    assert result.exit_code == 0, result.output
+    assert not node_modules.exists()
+
+
+def test_deletes_the_browser_binaries_in_the_default_location(
+    node_modules: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv(PLAYWRIGHT_BROWSERS_PATH, raising=False)
+    binaries = get_playwright_browser_path()
+    assert binaries.is_dir()
+
+    result = CliRunner().invoke(entry.clean_node)
+
+    assert result.exit_code == 0, result.output
+    assert not binaries.exists()
+
+
+def test_keeps_browsers_installed_outside_the_default_location(
+    node_modules: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    elsewhere = tmp_path / "shared-browsers"
+    elsewhere.mkdir()
+    (elsewhere / "chromium-1234").write_text("browser binary")
+    monkeypatch.setenv(PLAYWRIGHT_BROWSERS_PATH, str(elsewhere))
+
+    result = CliRunner().invoke(entry.clean_node)
+
+    assert result.exit_code == 0, result.output
+    assert not node_modules.exists()
+    assert (elsewhere / "chromium-1234").exists()
+
+
+def test_exits_zero_when_there_is_nothing_installed(
+    node_modules: Path, caplog: pytest.LogCaptureFixture
+):
+    shutil.rmtree(node_modules)
+
+    result = CliRunner().invoke(entry.clean_node)
+
+    assert result.exit_code == 0, result.output
+    assert "nothing to delete" in caplog.text
+
+
+def test_real_default_browser_location_is_inside_the_deleted_directory():
+    from Browser.entry.constant import NODE_MODULES  # noqa: PLC0415
+
+    assert get_playwright_browser_path().is_relative_to(NODE_MODULES)

--- a/utest/test_convert_options_types.py
+++ b/utest/test_convert_options_types.py
@@ -1,0 +1,101 @@
+from datetime import timedelta
+
+import pytest
+from robot.api import TypeInfo
+
+from Browser import Browser
+from Browser.entry.__main__ import convert_options_types
+from Browser.utils.data_types import RobotTypeConverter
+
+
+@pytest.fixture(scope="module")
+def browser() -> Browser:
+    return Browser()
+
+
+def test_no_options_converts_to_empty_params(browser: Browser):
+    assert convert_options_types([], browser) == {}
+
+
+def test_converts_values_to_the_keyword_argument_types(browser: Browser):
+    params = convert_options_types(
+        ["headless=True", "timeout=10 sec", "port=8282"], browser
+    )
+
+    assert params == {
+        "headless": True,
+        "timeout": timedelta(seconds=10),
+        "port": 8282,
+    }
+
+
+def test_converts_a_typed_dict_option(browser: Browser):
+    params = convert_options_types(["proxy={'server': 'http://localhost:1'}"], browser)
+
+    assert params == {"proxy": {"server": "http://localhost:1"}}
+
+
+def test_only_the_first_equals_sign_separates_name_from_value(browser: Browser):
+    params = convert_options_types(["wsPath=chromium/1?token=abc=def"], browser)
+
+    assert params == {"wsPath": "chromium/1?token=abc=def"}
+
+
+def test_every_launch_browser_server_option_is_convertible(browser: Browser):
+    keyword_types = browser.get_keyword_types("launch_browser_server")
+
+    unconvertible = [
+        name
+        for name, type_ in keyword_types.items()
+        if RobotTypeConverter.converter_for(type_) is None
+    ]
+
+    assert not unconvertible, f"No converter for options: {unconvertible}"
+
+
+def test_option_without_equals_sign_raises_runtime_error(browser: Browser):
+    with pytest.raises(
+        RuntimeError,
+        match=r"Invalid option headless\. Options must be in the form of argument_name=value",
+    ):
+        convert_options_types(["headless"], browser)
+
+
+def test_unknown_option_name_raises_runtime_error(browser: Browser):
+    with pytest.raises(
+        RuntimeError,
+        match=r"Invalid argument name nosuchoption\. Argument names must be one of ",
+    ):
+        convert_options_types(["nosuchoption=1"], browser)
+
+
+def test_bad_option_value_raises_robot_frameworks_value_error(browser: Browser):
+    # The two error shapes are the contract: a bad name is this command's own
+    # RuntimeError naming the CLI option, a bad value is Robot Framework's
+    # ValueError naming the keyword argument. See
+    # docs/research/rfbrowser-cli-coverage.md section 7 before changing either.
+    with pytest.raises(
+        ValueError,
+        match=r"Argument 'timeout' got value 'notatime' that cannot be converted to timedelta",
+    ):
+        convert_options_types(["timeout=notatime"], browser)
+
+
+def test_unconvertible_option_type_raises_runtime_error_not_attribute_error(
+    browser: Browser, monkeypatch: pytest.MonkeyPatch
+):
+    # No real option reaches this branch on any supported Robot Framework version,
+    # so converter_for is forced to return None to drive it.
+    monkeypatch.setattr(
+        RobotTypeConverter, "converter_for", staticmethod(lambda *args, **kwargs: None)
+    )
+
+    with pytest.raises(RuntimeError, match=r"Invalid option timeout\."):
+        convert_options_types(["timeout=10 sec"], browser)
+
+
+def test_converter_accepts_a_type_info():
+    converter = RobotTypeConverter.converter_for(TypeInfo.from_type(int))
+
+    assert converter is not None
+    assert converter.convert(name="port", value="8282") == 8282

--- a/utest/test_entry_uninstall.py
+++ b/utest/test_entry_uninstall.py
@@ -1,0 +1,80 @@
+import pytest
+from click.testing import CliRunner
+
+from Browser.entry import __main__ as entry
+from Browser.entry.constant import PLAYWRIGHT_BROWSERS_PATH
+
+
+class FakeBrowserLib:
+    def __init__(self, error: Exception | None = None):
+        self.calls: list[tuple] = []
+        self._error = error
+
+    def execute_npx_playwright(self, *args):
+        self.calls.append(args)
+        if self._error:
+            raise self._error
+
+
+@pytest.fixture(autouse=True)
+def isolated_browsers_path(monkeypatch: pytest.MonkeyPatch):
+    # ensure_playwright_browsers_path writes PLAYWRIGHT_BROWSERS_PATH into
+    # os.environ and never removes it. Without this stub the variable escapes into
+    # the rest of the pytest session and points every browser-backed test at a
+    # directory that does not exist.
+    monkeypatch.setattr(entry, "ensure_playwright_browsers_path", lambda: None)
+    monkeypatch.delenv(PLAYWRIGHT_BROWSERS_PATH, raising=False)
+
+
+@pytest.fixture
+def browser_lib(monkeypatch: pytest.MonkeyPatch) -> FakeBrowserLib:
+    lib = FakeBrowserLib()
+    monkeypatch.setattr(entry, "get_browser_lib", lambda: lib)
+    return lib
+
+
+def test_runs_npx_playwright_uninstall(browser_lib: FakeBrowserLib):
+    result = CliRunner().invoke(entry.uninstall)
+
+    assert result.exit_code == 0, result.output
+    assert browser_lib.calls == [("uninstall",)]
+
+
+def test_all_flag_is_forwarded_to_npx(browser_lib: FakeBrowserLib):
+    result = CliRunner().invoke(entry.uninstall, ["--all"])
+
+    assert result.exit_code == 0, result.output
+    assert browser_lib.calls == [("uninstall", "--all")]
+
+
+def test_browsers_path_is_resolved_before_the_library_is_built(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Resolving it later would leave npx looking in Playwright's own default
+    # location instead of this installation's, and it would remove nothing.
+    order: list[str] = []
+    lib = FakeBrowserLib()
+    monkeypatch.setattr(
+        entry, "ensure_playwright_browsers_path", lambda: order.append("ensure")
+    )
+    monkeypatch.setattr(
+        entry, "get_browser_lib", lambda: (order.append("get_lib"), lib)[1]
+    )
+
+    result = CliRunner().invoke(entry.uninstall)
+
+    assert result.exit_code == 0, result.output
+    assert order == ["ensure", "get_lib"]
+
+
+def test_a_failing_npx_uninstall_still_exits_zero():
+    # contextlib.suppress(Exception) in the command, pinned so that a change to it
+    # is deliberate. It is why the exit code alone is not evidence of success.
+    lib = FakeBrowserLib(error=RuntimeError("npx exploded"))
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(entry, "get_browser_lib", lambda: lib)
+        result = CliRunner().invoke(entry.uninstall)
+
+    assert result.exit_code == 0, result.output
+    assert lib.calls == [("uninstall",)]


### PR DESCRIPTION
Records a decision for every rfbrowser command in
docs/research/rfbrowser-cli-coverage.md and closes the gaps that were cheap to close.

The ticket's inventory was wrong on four of nine rows. transform, translation and coverage were listed as run "nowhere" but each has direct acceptance coverage. show-trace was listed as verified directly but had no real coverage at all, three ways over:

  - the test was gated on ${SYS_VAR_CI}, which only inv atest-global-pythonpath sets and no workflow invokes, so it logged a message instead of testing;
  - the helpers passed a list to subprocess with shell=True, which on POSIX runs only the first element, so rfbrowser was started with no arguments and the help assertion matched the top level group's help, not show-trace's;
  - the viewer was started with -F, an option show-trace does not have.

show-trace now has a help check that runs everywhere and a viewer check that starts a real trace viewer. The viewer check inherits the slow tag from the test that produces its trace file, so smoke runs exclude producer and consumer together.

clean-node's result is asserted after the fact in CI by .github/scripts/verify_clean_node.py, and utest/test_clean_node.py pins the deletion semantics, including that browser binaries go with the dependencies only because they live inside them.

uninstall stays manual - npx playwright uninstall removes the shared browser binaries every later test in the job needs - but its delegation is pinned in utest/test_entry_uninstall.py.

convert_options_types keeps its conversion, per the maintainer, so the command reports both failure modes in one error style and stays independent of the attributes proxy. utest/test_convert_options_types.py now pins that contract; it did not exist despite the ticket stating it did. converter_for is also guarded against returning None, which would otherwise surface as an AttributeError on Robot Framework <= 7.2.