### PR TITLE
fix init.doc field on translation.json

### DIFF
--- a/Browser/entry/translation.py
+++ b/Browser/entry/translation.py
@@ -45,7 +45,7 @@ def get_library_translation(
         }
     translation["__init__"] = {
         "name": "__init__",
-        "doc": inspect.getdoc(browser),
+        "doc": inspect.getdoc(browser.__init__),
         "sha256": hashlib.sha256(inspect.getdoc(browser).encode("utf-16")).hexdigest(),  # type: ignore
     }
     translation["__intro__"] = {


### PR DESCRIPTION
I'm translating Browser Library in french with robotframework-browser-translation.
There is an issue on the json translation file generated by the command : "uv run python -m Browser.entry translation robotframework_browser_translation/translation_xx.json".

The init.doc field contains the same text as intro.doc field. So when you generate a html documentation with libdoc command : "python3 -m robot.libdoc "Browser::language=fr" browser_xxx.html".
The generated file contains the introduction twice : once in "introduction" section and in "importing" section.

I'v tried this modification on Browser Library and it worked :
on line 48 of "Browser/entry/translation.py" :
old :  inspect.getdoc(browser)
new : inspect.getdoc(browser.__init__ )

The generated json contains the right text in init.doc field and the html documentation introduction section is ok.