### PR TITLE
fix translation.py for init.doc field with mypy OK

### DIFF
--- a/Browser/entry/translation.py
+++ b/Browser/entry/translation.py
@@ -45,8 +45,8 @@ def get_library_translation(
         }
     translation["__init__"] = {
         "name": "__init__",
-        "doc": inspect.getdoc(browser),
-        "sha256": hashlib.sha256(inspect.getdoc(browser).encode("utf-16")).hexdigest(),  # type: ignore
+        "doc": inspect.getdoc(Browser.__init__),
+        "sha256": hashlib.sha256(inspect.getdoc(Browser.__init__).encode("utf-16")).hexdigest(),  # type: ignore
     }
     translation["__intro__"] = {
         "name": "__intro__",


### PR DESCRIPTION
fix mypy error for translation.py PR #5193.
2 modifications on lines 48 and 49
old PR :
 Line 48 : `"doc": inspect.getdoc(browser.__init__),`
Line 49 : no changes

new PR :
Line 48 : `"doc": inspect.getdoc(Browser.__init__),`
Line 49 : `"sha256": hashlib.sha256(inspect.getdoc(Browser.__init__).encode("utf-16")).hexdigest(),`