### PR TITLE
chore: move close_deadline_floor_secs do library instance

### DIFF
--- a/Browser/base/librarycomponent.py
+++ b/Browser/base/librarycomponent.py
@@ -366,3 +366,13 @@ class LibraryComponent:
         return self.library.evaluate_javascript(
             selector, f"{element_selector}.{function}"
         )
+
+    @property
+    def close_deadline(self) -> float:
+        """How long the closing calls may take, in seconds.
+
+        ``self.timeout`` is in milliseconds and gRPC deadlines are in seconds,
+        hence the conversion. The deadline is there so that a browser that
+        never finishes closing cannot hang the whole run, see issue #4124.
+        """
+        return max(self.library.close_deadline_floor_secs, self.timeout / 1000 * 2)

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -591,6 +591,7 @@ class Browser(DynamicCore):
         )
         self.scope_stack["keyword_call_banner_add_style"] = SettingsStack("", self)
         self.scope_stack["assertion_formatter"] = SettingsStack({}, self)
+        self.close_deadline_floor_secs = 20
 
     @property
     def presenter_mode(self) -> HighLightElement | bool:

--- a/Browser/keywords/playwright_state.py
+++ b/Browser/keywords/playwright_state.py
@@ -59,11 +59,6 @@ from ..utils import (
 )
 from ..utils.logger import LOGLEVEL
 
-# Twice the library's own default timeout of 10 seconds. Closing is cleanup:
-# how long it takes has nothing to do with how long the user is willing to
-# wait for a click, so a short Browser timeout must not shorten it.
-CLOSE_DEADLINE_FLOOR_SECS = 20.0
-
 
 class PlaywrightState(LibraryComponent):
     """Keywords to manage Playwright side Browsers, Contexts and Pages."""
@@ -119,16 +114,6 @@ class PlaywrightState(LibraryComponent):
         if pause_on_failure:
             self.library.pause_on_failure.add(browser_id)
 
-    @property
-    def _close_deadline(self) -> float:
-        """How long the closing calls may take, in seconds.
-
-        ``self.timeout`` is in milliseconds and gRPC deadlines are in seconds,
-        hence the conversion. The deadline is there so that a browser that
-        never finishes closing cannot hang the whole run, see issue #4124.
-        """
-        return max(CLOSE_DEADLINE_FLOOR_SECS, self.timeout / 1000 * 2)
-
     @keyword(tags=("Setter", "BrowserControl"))
     def close_browser(self, browser: SelectionType | str = SelectionType.CURRENT):
         """Closes the current browser.
@@ -160,7 +145,7 @@ class PlaywrightState(LibraryComponent):
         with self.playwright.grpc_channel() as stub:
             if browser == SelectionType.ALL:
                 response = stub.CloseAllBrowsers(
-                    Request().Empty(), timeout=self._close_deadline
+                    Request().Empty(), timeout=self.close_deadline
                 )
                 self.library.pause_on_failure.clear()
                 logger.info(response.log)
@@ -169,7 +154,7 @@ class PlaywrightState(LibraryComponent):
             if browser != SelectionType.CURRENT:
                 self.switch_browser(browser)
 
-            response = stub.CloseBrowser(Request.Empty(), timeout=self._close_deadline)
+            response = stub.CloseBrowser(Request.Empty(), timeout=self.close_deadline)
             closed_browser_id = response.body
             self.delete_browser_id_from_arg_mapping(closed_browser_id)
             self._update_tracing_contexts()
@@ -244,7 +229,7 @@ class PlaywrightState(LibraryComponent):
                 self.context_cache.remove(context["id"])
                 self.switch_context(context["id"])
                 response = stub.CloseContext(
-                    Request().Bool(value=save_trace), timeout=self._close_deadline
+                    Request().Bool(value=save_trace), timeout=self.close_deadline
                 )
                 logger.info(response.log)
 

--- a/utest/test_close_deadline.py
+++ b/utest/test_close_deadline.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock
 import pytest
 
 import Browser
-from Browser.keywords.playwright_state import CLOSE_DEADLINE_FLOOR_SECS
 from Browser.utils.data_types import Scope
 
 
@@ -65,7 +64,7 @@ def test_closing_never_gets_less_than_the_floor(closing_keyword, browser_timeout
         closing_keyword(library)
     assert deadlines, f"{closing_keyword.__name__} made no closing call"
     rpc, deadline = deadlines[-1]
-    assert deadline == pytest.approx(CLOSE_DEADLINE_FLOOR_SECS), (
+    assert deadline == pytest.approx(library.close_deadline_floor_secs), (
         f"{rpc} asked for a {deadline} second deadline with a "
         f"{browser_timeout} Browser timeout"
     )


### PR DESCRIPTION
So that it is possible to change it from library side

Fixes: #5214