### PR TITLE
fix: dedent documentation before storing translation checksums

### DIFF
--- a/Browser/entry/translation.py
+++ b/Browser/entry/translation.py
@@ -41,23 +41,12 @@ def get_library_translation(
         translation[function.__name__] = _translation_entry(
             function.__name__, inspect.getdoc(function)
         )
-    # Both entries describe the class docstring; see issue #5220.
     translation["__init__"] = _translation_entry("__init__", inspect.getdoc(browser))
     translation["__intro__"] = _translation_entry("__intro__", inspect.getdoc(browser))
     return translation
 
 
 def _translation_entry(name: str, doc: str | None) -> dict:
-    """Build one translation entry from a docstring, dedenting it first.
-
-    Python 3.13 strips leading indentation from docstrings, so the same
-    docstring reaches this function indented on Python 3.12 and dedented on
-    3.13. Hashing it as-is would produce a different checksum per Python
-    version and make a translation file valid only on one side of that
-    boundary. Normalising with ``inspect.cleandoc`` makes the stored
-    documentation and its checksum identical on every supported version.
-    See issue #5219.
-    """
     doc = inspect.cleandoc(doc) if doc else ""
     return {
         "name": name,

--- a/Browser/entry/translation.py
+++ b/Browser/entry/translation.py
@@ -38,22 +38,32 @@ def get_library_translation(
     browser = Browser(plugins=plugings, jsextension=jsextension)
     translation = {}
     for function in browser.attributes.values():
-        translation[function.__name__] = {
-            "name": function.__name__,
-            "doc": function.__doc__,
-            "sha256": hashlib.sha256(function.__doc__.encode("utf-16")).hexdigest(),
-        }
-    translation["__init__"] = {
-        "name": "__init__",
-        "doc": inspect.getdoc(browser),
-        "sha256": hashlib.sha256(inspect.getdoc(browser).encode("utf-16")).hexdigest(),  # type: ignore
-    }
-    translation["__intro__"] = {
-        "name": "__intro__",
-        "doc": browser.__doc__,
-        "sha256": hashlib.sha256(browser.__doc__.encode("utf-16")).hexdigest(),  # type: ignore
-    }
+        translation[function.__name__] = _translation_entry(
+            function.__name__, inspect.getdoc(function)
+        )
+    # Both entries describe the class docstring; see issue #5220.
+    translation["__init__"] = _translation_entry("__init__", inspect.getdoc(browser))
+    translation["__intro__"] = _translation_entry("__intro__", inspect.getdoc(browser))
     return translation
+
+
+def _translation_entry(name: str, doc: str | None) -> dict:
+    """Build one translation entry from a docstring, dedenting it first.
+
+    Python 3.13 strips leading indentation from docstrings, so the same
+    docstring reaches this function indented on Python 3.12 and dedented on
+    3.13. Hashing it as-is would produce a different checksum per Python
+    version and make a translation file valid only on one side of that
+    boundary. Normalising with ``inspect.cleandoc`` makes the stored
+    documentation and its checksum identical on every supported version.
+    See issue #5219.
+    """
+    doc = inspect.cleandoc(doc) if doc else ""
+    return {
+        "name": name,
+        "doc": doc,
+        "sha256": hashlib.sha256(doc.encode("utf-16")).hexdigest(),
+    }
 
 
 def _max_kw_name_lenght(project_tanslation: dict) -> int:

--- a/utest/test_python_arguments.py
+++ b/utest/test_python_arguments.py
@@ -340,7 +340,8 @@ def test_rfbrowser_translate_reads_the_documentation_of_unwrapped_methods(tmpdir
     translation = get_library_translation()
     library = Browser()
     documentation = {
-        keyword.__name__: keyword.__doc__ for keyword in library.keywords.values()
+        keyword.__name__: inspect.getdoc(keyword)
+        for keyword in library.keywords.values()
     }
     for name, entry in translation.items():
         if name in ["__init__", "__intro__"]:

--- a/utest/test_rfbrowser_translate.py
+++ b/utest/test_rfbrowser_translate.py
@@ -1,3 +1,5 @@
+import hashlib
+
 from approvaltests import verify_all
 
 from Browser.entry.translation import (
@@ -7,6 +9,7 @@ from Browser.entry.translation import (
     NO_LIB_KEYWORD,
     _get_heading,
     _table_doc_updated,
+    _translation_entry,
 )
 
 
@@ -40,3 +43,31 @@ def test_full_long_kw_table():
     )
     lines.append(_table_doc_updated("close", 42, DOC_CHANGED))
     verify_all("all with long kw name", lines)
+
+
+# Docstring as it reaches the entry builder on Python <= 3.12 and on >= 3.13.
+# Python 3.13 strips the leading indentation at compile time, see issue #5219.
+INDENTED_DOC = "First line.\n\n        Indented body line.\n    "
+DEDENTED_DOC = "First line.\n\nIndented body line.\n"
+
+
+def test_translation_entry_dedents_documentation():
+    assert (
+        _translation_entry("kw", INDENTED_DOC)["doc"]
+        == "First line.\n\nIndented body line."
+    )
+
+
+def test_translation_entry_checksum_does_not_depend_on_python_version():
+    indented = _translation_entry("kw", INDENTED_DOC)
+    dedented = _translation_entry("kw", DEDENTED_DOC)
+    assert indented["sha256"] == dedented["sha256"]
+    assert indented["doc"] == dedented["doc"]
+
+
+def test_translation_entry_handles_missing_documentation():
+    assert _translation_entry("kw", None) == {
+        "name": "kw",
+        "doc": "",
+        "sha256": hashlib.sha256(b"\xff\xfe").hexdigest(),
+    }


### PR DESCRIPTION
Fixes #5219.

## Problem

`get_library_translation()` hashes the raw `function.__doc__`. Python 3.13 strips leading indentation from docstrings ([gh-81283](https://github.com/python/cpython/issues/81283)), so the checksum of every keyword depends on the Python version that generated the translation file.

Generating from Browser 20.4.0 on three interpreters:

| Comparison | Entries with differing `sha256` |
|---|---|
| 3.10 vs 3.12 | 0 of 154 |
| 3.12 vs 3.14 | **153 of 154** |
| 3.10 vs 3.14 | **153 of 154** |

A translation file is therefore only valid on one side of the 3.12/3.13 boundary. `rfbrowser translation --compare` reports near-total false drift for anyone on the other side, and a CI matrix that spans the boundary can never pass.

The one stable entry, `__init__`, is also the only one built with `inspect.getdoc()` — which calls `cleandoc()` and dedents. That is the fix.

## Change

Entry construction is pulled into `_translation_entry()`, which normalises the docstring with `inspect.cleandoc()` before storing and hashing it. It also handles a `None` docstring, which the previous code would have crashed on (`function.__doc__.encode(...)`).

After the change the generated file is identical on 3.12 and 3.14:

```
final patch -> 3.12 vs 3.14 differing: 0 of 154
```

## Tests

Three unit tests on `_translation_entry`, deliberately written to be **interpreter-independent**. My first attempt asserted over the real generated translation, but that version would pass on 3.13+ even without the fix, because the compiler has already dedented by then. These instead feed in both docstring forms explicitly:

```python
INDENTED_DOC = "First line.\n\n        Indented body line.\n    "   # <= 3.12 __doc__
DEDENTED_DOC = "First line.\n\nIndented body line.\n"                # >= 3.13 __doc__
```

and assert the two produce the same `doc` and the same `sha256`. Verified against the old implementation, they fail exactly as intended:

```
old sha equal across versions? False
new sha equal across versions? True
```

Passing on 3.10, 3.12 and 3.14 (`3 passed` each). `ruff format --check` and `ruff check` are clean on both changed files.

I was not able to run the full `utest` suite locally — it needs the generated protobuf modules from `inv build`, and the approvaltests-based tests in this file open a diff reporter when their approved files are not on the path. The three new tests were run in isolation against an installed Browser with this patch applied.

## Impact on downstream translation packages

This moves 153 of 154 checksums, so every translation package regenerates once. For `robotframework-browser-translation`, the split is:

- **127** keywords whose English documentation genuinely changed and needs re-translation
- **21** keywords that are pure dedent churn — byte-identical under `inspect.cleandoc`, checksum-only updates

## Note on `__intro__` / `__init__`

`__intro__` now uses `inspect.getdoc(browser)` as well, which makes it byte-identical to `__init__`. That duplication is **pre-existing** — both entries already described the class docstring, one cleaned and one raw — and is reported separately in #5220, where the `__init__` entry should instead come from `Browser.__init__`. Fixing that changes which docstring `__init__` translates, so it is deliberately out of scope here.

Since this PR already forces a one-time regeneration for every translation package, it may be worth landing #5220 alongside it so downstream projects regenerate once rather than twice. Happy to extend this PR if you prefer that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZZ2SLerQY9yqgHzj84crs
