### PR TITLE
fix: build the __init__ translation entry from the import documentation

### DIFF
--- a/Browser/entry/translation.py
+++ b/Browser/entry/translation.py
@@ -41,7 +41,9 @@ def get_library_translation(
         translation[function.__name__] = _translation_entry(
             function.__name__, inspect.getdoc(function)
         )
-    translation["__init__"] = _translation_entry("__init__", inspect.getdoc(browser))
+    translation["__init__"] = _translation_entry(
+        "__init__", inspect.getdoc(type(browser).__init__)
+    )
     translation["__intro__"] = _translation_entry("__intro__", inspect.getdoc(browser))
     return translation
 

--- a/atest/test/12_rfbrowser/translation.robot
+++ b/atest/test/12_rfbrowser/translation.robot
@@ -25,11 +25,12 @@ Create Translation File With Python Plugin
     ${data} =    Verify Translation    ${OUTPUT_DIR}/translation.json
     Should Be True    ${data}[this_is_plugin_keyword]
     VAR    ${inro} =    ${data}[__intro__]
-    Should Start With    ${inro}[doc]    Browser library${SPACE}
+    Should Start With    ${inro}[doc]    Browser library is a browser automation library
     Should Be Equal    ${inro}[name]    __intro__
     VAR    ${init} =    ${data}[__init__]
-    Should Start With    ${init}[doc]    Browser library${SPACE}
+    Should Start With    ${init}[doc]    Browser library can be taken into use with optional arguments:
     Should Be Equal    ${init}[name]    __init__
+    Should Not Be Equal    ${init}[doc]    ${inro}[doc]
     [Teardown]    Remove File    ${OUTPUT_DIR}/translation.json
 
 Create Translation File With JS Plugin

--- a/utest/test_rfbrowser_translate.py
+++ b/utest/test_rfbrowser_translate.py
@@ -1,7 +1,10 @@
 import hashlib
+import inspect
 
+import pytest
 from approvaltests import verify_all
 
+from Browser import Browser
 from Browser.entry.translation import (
     DOC_CHANGED,
     MISSING_CHECKSUM,
@@ -10,6 +13,7 @@ from Browser.entry.translation import (
     _get_heading,
     _table_doc_updated,
     _translation_entry,
+    get_library_translation,
 )
 
 
@@ -71,3 +75,27 @@ def test_translation_entry_handles_missing_documentation():
         "doc": "",
         "sha256": hashlib.sha256(b"\xff\xfe").hexdigest(),
     }
+
+
+@pytest.fixture
+def _library_output_dir(tmp_path):
+    """Keep the library instance from unlinking playwright-log.txt in the cwd."""
+    original = Browser._output_dir
+    Browser._output_dir = tmp_path
+    yield
+    Browser._output_dir = original
+
+
+@pytest.mark.usefixtures("_library_output_dir")
+def test_library_translation_init_documents_import_arguments():
+    """``__init__`` must document the import arguments, not the library intro."""
+    translation = get_library_translation()
+    init_doc = translation["__init__"]["doc"]
+    assert init_doc == inspect.getdoc(Browser.__init__)
+    assert init_doc != translation["__intro__"]["doc"]
+
+
+@pytest.mark.usefixtures("_library_output_dir")
+def test_library_translation_intro_is_class_documentation():
+    translation = get_library_translation()
+    assert translation["__intro__"]["doc"] == inspect.getdoc(Browser)


### PR DESCRIPTION
__init__ now uses inspect.getdoc(type(browser).__init__); __intro__ keeps the class docstring.

Fixes #5220