### PR TITLE
chore: make scope test less flaky.

### DIFF
--- a/Browser/base/librarycomponent.py
+++ b/Browser/base/librarycomponent.py
@@ -60,7 +60,7 @@ class LibraryComponent:
 
     @property
     def keyword_call_banner_add_style(self) -> str:
-        return self.library.scope_stack["keyword_call_banner_add_style"].get()
+        return self.library.keyword_call_banner_add_style
 
     @property
     def keyword_call_banner_add_style_stack(self) -> SettingsStack:
@@ -72,7 +72,7 @@ class LibraryComponent:
 
     @property
     def show_keyword_call_banner(self) -> bool:
-        return self.library.scope_stack["show_keyword_call_banner"].get()
+        return self.library.show_keyword_call_banner
 
     @property
     def show_keyword_call_banner_stack(self) -> SettingsStack:
@@ -84,7 +84,7 @@ class LibraryComponent:
 
     @property
     def run_on_failure_keyword(self) -> DelayedKeyword:
-        return self.library.scope_stack["run_on_failure"].get()
+        return self.library.run_on_failure_keyword
 
     @property
     def run_on_failure_keyword_stack(self) -> SettingsStack:
@@ -96,7 +96,7 @@ class LibraryComponent:
 
     @property
     def highlight_on_failure(self) -> bool:
-        return self.library.scope_stack["highlight_on_failure"].get()
+        return self.library.highlight_on_failure
 
     @property
     def highlight_on_failure_stack(self) -> SettingsStack:
@@ -122,7 +122,7 @@ class LibraryComponent:
 
     @property
     def timeout(self) -> float:
-        return self.library.scope_stack["timeout"].get()
+        return self.library.timeout
 
     @property
     def timeout_stack(self) -> SettingsStack:
@@ -134,7 +134,7 @@ class LibraryComponent:
 
     @property
     def retry_assertions_for(self) -> float:
-        return self.library.scope_stack["retry_assertions_for"].get()
+        return self.library.retry_assertions_for
 
     @property
     def retry_assertions_for_stack(self) -> SettingsStack:
@@ -146,7 +146,7 @@ class LibraryComponent:
 
     @property
     def selector_prefix(self) -> str:
-        return self.library.scope_stack["selector_prefix"].get()
+        return self.library.selector_prefix
 
     @property
     def selector_prefix_stack(self) -> SettingsStack:
@@ -316,7 +316,7 @@ class LibraryComponent:
 
     @property
     def strict_mode(self) -> bool:
-        return self.library.scope_stack["strict_mode"].get()
+        return self.library.strict_mode
 
     @property
     def strict_mode_stack(self) -> SettingsStack:

--- a/Browser/browser.py
+++ b/Browser/browser.py
@@ -649,8 +649,20 @@ class Browser(DynamicCore):
         return self.scope_stack["highlight_on_failure"].get()
 
     @property
-    def timeout(self):
+    def timeout(self) -> float:
         return self.scope_stack["timeout"].get()
+
+    @property
+    def retry_assertions_for(self) -> float:
+        return self.scope_stack["retry_assertions_for"].get()
+
+    @property
+    def strict_mode(self) -> bool:
+        return self.scope_stack["strict_mode"].get()
+
+    @property
+    def selector_prefix(self) -> str:
+        return self.scope_stack["selector_prefix"].get()
 
     def _parse_run_on_failure_keyword(self, keyword: str | None) -> DelayedKeyword:
         if keyword is None or is_falsy(keyword):

--- a/atest/test/08_Scope_Tests/Suite_1/Suite_1.1/Suite_1.1.1.robot
+++ b/atest/test/08_Scope_Tests/Suite_1/Suite_1.1/Suite_1.1.1.robot
@@ -8,10 +8,10 @@ Test Timeout    30 sec
 *** Test Cases ***
 Test Scope Settings Override Global Defaults
     Log All Scopes    1000    1000    False    ${EMPTY}
-    Timeout Should Be Between    500    1700
+    Timeout Should Be    1000
     ${global_timeout} =    Set Browser Timeout    2s    scope=Test
     Should Be Equal    ${global_timeout}    1 second
-    Timeout Should Be Between    1500    3000
+    Timeout Should Be    2000
 
     Go To    ${WAIT_URL_DIRECT}
     Strict Mode Should Be    False
@@ -20,12 +20,12 @@ Test Scope Settings Override Global Defaults
     Strict Mode Should Be    True
 
     Go To    ${WAIT_URL_DIRECT}
-    Assertion Retry Should Be Between    500    1700
+    Assertion Retry Should Be    1000
     ${global_retry} =    Set Retry Assertions For    2s    scope=Test
     Should Be Equal    ${global_retry}    1 second
-    Assertion Retry Should Be Between    1500    3000
+    Assertion Retry Should Be    2000
 
-    Go To    ${WAIT_URL_FRAMED}
+    Open Framed Page
     ${global_prefix} =    Set Selector Prefix    ${IFRAME_PREFIX}    scope=Test
     Should Be Equal    ${global_prefix}    ${EMPTY}
     Strict Mode Should Be    True
@@ -34,9 +34,9 @@ Test Scope Settings Override Global Defaults
 
 Global Defaults Are Restored When Test Scope Ends
     Log All Scopes    1000    1000    False    ${EMPTY}
-    Timeout Should Be Between    500    1700
+    Timeout Should Be    1000
     Strict Mode Should Be    ${False}
-    Assertion Retry Should Be Between    500    1700
+    Assertion Retry Should Be    1000
 
 Settings Set At Suite Scope Are Applied To Current Test
     Set Strict Mode    ${True}
@@ -47,8 +47,8 @@ Settings Set At Suite Scope Are Applied To Current Test
     Log All Scopes    500    500    True    ${IFRAME_PREFIX}
 
 Suite Scope Settings Persist Into Subsequent Tests
-    [Setup]    Go To    ${WAIT_URL_FRAMED}
+    [Setup]    Open Framed Page
     Log All Scopes    500    500    True    ${IFRAME_PREFIX}
     Strict Mode Should Be    True
-    Timeout Should Be Between    300    900
-    Assertion Retry Should Be Between    300    900
+    Timeout Should Be    500
+    Assertion Retry Should Be    500

--- a/atest/test/08_Scope_Tests/Suite_1/Suite_1.1/Suite_1.1.2.robot
+++ b/atest/test/08_Scope_Tests/Suite_1/Suite_1.1/Suite_1.1.2.robot
@@ -8,8 +8,8 @@ Test Setup     Go To    ${WAIT_URL_DIRECT}
 Test Suite Level Removed
     Log All Scopes    1000    1000    False    ${EMPTY}
     Strict Mode Should Be    False
-    Timeout Should Be Between    500    1500
-    Assertion Retry Should Be Between    500    1500
+    Timeout Should Be    1000
+    Assertion Retry Should Be    1000
 
 Set Global Scope
     Log All Scopes    1000    1000    False    ${EMPTY}

--- a/atest/test/08_Scope_Tests/Suite_1/Suite_1.1/Suite_1.1.3.robot
+++ b/atest/test/08_Scope_Tests/Suite_1/Suite_1.1/Suite_1.1.3.robot
@@ -7,20 +7,14 @@ Test Setup        New Page    ${WAIT_URL_FRAMED}
 
 *** Test Cases ***
 Test Normal Timeout
-    Select Options By    \#dropdown    value    enabled
-    Click With Options    \#submit    noWaitAfter=True
-    Click    "victim"
+    Timeout Should Be    1500
 
 Set Timeout To Test Scope
-    Select Options By    \#dropdown    value    enabled
-    Click With Options    \#submit    noWaitAfter=True
     Set Browser Timeout    100ms    scope=Test
-    Run Keyword And Expect Error    *Timeout 100ms exceeded.*    Click    "victim"
+    Timeout Should Be    100
 
 Verify Removed Scope
-    Select Options By    \#dropdown    value    enabled
-    Click With Options    \#submit    noWaitAfter=True
-    Click    "victim"
+    Timeout Should Be    1500
 
 Set Run On Failure To Test Scope
     Register Keyword To Run On Failure    LocalStorage Set Item    test_name    ${TEST_NAME}    scope=Test

--- a/atest/test/08_Scope_Tests/Suite_1/Suite_1.2/Suite_1.2.1.robot
+++ b/atest/test/08_Scope_Tests/Suite_1/Suite_1.2/Suite_1.2.1.robot
@@ -1,11 +1,11 @@
 *** Settings ***
 Resource       ../../scope_keywords.resource
 
-Suite Setup    Ensure Open Page    ${WAIT_URL_FRAMED}
+Suite Setup    Ensure Open Framed Page
 
 *** Test Cases ***
 Test Suite Level Removed
     Log All Scopes    1500    1500    True    ${IFRAME_PREFIX}
     Strict Mode Should Be    True
-    Timeout Should Be Between    1000    2000
-    Assertion Retry Should Be Between    1000    2000
+    Timeout Should Be    1500
+    Assertion Retry Should Be    1500

--- a/atest/test/08_Scope_Tests/Suite_2/Suite_2.1/Suite_2.1.1.robot
+++ b/atest/test/08_Scope_Tests/Suite_2/Suite_2.1/Suite_2.1.1.robot
@@ -8,8 +8,8 @@ Test Setup     Go To    ${WAIT_URL_DIRECT}
 Test Suite Level Removed
     Log All Scopes    1000    1000    False    ${EMPTY}
     Strict Mode Should Be    False
-    Timeout Should Be Between    600    1500
-    Assertion Retry Should Be Between    600    1500
+    Timeout Should Be    1000
+    Assertion Retry Should Be    1000
 
 Altering Levels1
     [Setup]    New Page    about:blank

--- a/atest/test/08_Scope_Tests/scope_keywords.resource
+++ b/atest/test/08_Scope_Tests/scope_keywords.resource
@@ -3,43 +3,37 @@ Resource    ../keywords.resource
 Library     scope_logger.py
 
 *** Variables ***
-${SERVER_URL} =         http://${SERVER}/
-${FRAME_URL} =          framing.html?url=
-${IFRAME_PREFIX} =      id=iframe_id >>>
-${WAIT_URL_FRAMED} =    ${SERVER_URL}${FRAME_URL}waitfor.html
-${WAIT_URL_DIRECT} =    ${SERVER_URL}waitfor.html
+${SERVER_URL} =            http://${SERVER}/
+${FRAME_URL} =             framing.html?url=
+${IFRAME_PREFIX} =         id=iframe_id >>>
+${WAIT_URL_FRAMED} =       ${SERVER_URL}${FRAME_URL}waitfor.html
+${WAIT_URL_DIRECT} =       ${SERVER_URL}waitfor.html
+${FRAME_LOAD_TIMEOUT} =    10 s
 
 *** Keywords ***
-Timeout Should Be Between
-    [Arguments]    ${low}    ${high}
-    ${start_time} =    Get Current Date
-    Run Keyword And Expect Error    *    Wait For Condition    Element States    id=not_here    contains    hidden
-    Assert Passed Duration    ${start_time}    ${high}
-    ${start_time} =    Get Current Date
-    Wait For Condition    Element States    id=setdelay    contains    visible    timeout=${high} ms
-    Assert Passed Duration    ${start_time}    ${high}
-    ${start_time} =    Get Current Date
-    Wait For Condition    Element States    id=setdelay    contains    visible
-    Assert Passed Duration    ${start_time}    ${low}
-    ${start_time} =    Get Current Date
-    Wait For Condition    Element States    id=setdelay    contains    visible    timeout=${high} ms
-    Assert Passed Duration    ${start_time}    ${high}
+Timeout Should Be
+    [Documentation]    Reads the effective browser timeout out of Playwright's own error,
+    ...    which names the timeout it used: `Timeout 1000ms exceeded`. That is an exact
+    ...    readout rather than a duration to infer a value from, so a stalled CI runner
+    ...    cannot change the answer.
+    [Arguments]    ${expected_ms}
+    Run Keyword And Expect Error
+    ...    *Timeout ${expected_ms}ms exceeded*
+    ...    Click    id=not_here
 
-Assertion Retry Should Be Between
-    [Arguments]    ${low}    ${high}
+Assertion Retry Should Be
+    [Documentation]    Asserts the assertion retry budget was honoured, as a lower bound.
+    ...    Nothing in the failure names the retry budget the way Playwright names its
+    ...    timeout, so a duration is the only reading available - see
+    ...    https://github.com/MarketSquare/robotframework-browser/issues/5223. A lower
+    ...    bound is the only stall-proof way to take it: the polling loop gives up only
+    ...    once the budget is spent, so a loaded runner makes this longer, never shorter.
+    ...    Assumes the retry budget is not larger than the browser timeout, which would
+    ...    end the loop early.
+    [Arguments]    ${expected_ms}
     ${start_time} =    Get Current Date
     Run Keyword And Expect Error    *    Get Element States    id=not_here    contains    readonly
-    Assert Passed Duration    ${start_time}    ${high}
-    ${start_time} =    Get Current Date
-    Wait For Condition    Element States    id=setdelay    contains    visible    timeout=${high} ms
-    Assert Passed Duration    ${start_time}    ${high}
-
-    ${start_time} =    Get Current Date
-    Get Element States    id=setdelay    contains    visible
-    Assert Passed Duration    ${start_time}    ${low}
-    ${start_time} =    Get Current Date
-    Wait For Condition    Element States    id=setdelay    contains    visible    timeout=${high} ms
-    Assert Passed Duration    ${start_time}    ${high}
+    Assert Retried For At Least    ${start_time}    ${expected_ms}
 
 Strict Mode Should Be
     [Arguments]    ${status}
@@ -48,3 +42,25 @@ Strict Mode Should Be
     ELSE
         Get Text    input
     END
+
+Wait For Framed Page
+    [Documentation]    Waits for the iframe's own document. framing.html sets the iframe
+    ...    src from a script, so the outer page's load event does not reliably cover the
+    ...    frame. Without this a slow frame is indistinguishable from a scope setting that
+    ...    did not apply, because both surface as a timeout on the very next keyword.
+    ...    The selector is prefix-muted so it reads the same whether or not a selector
+    ...    prefix is in scope.
+    Wait For Elements State
+    ...    !prefix ${IFRAME_PREFIX} id=setdelay
+    ...    attached
+    ...    ${FRAME_LOAD_TIMEOUT}
+
+Open Framed Page
+    [Documentation]    Navigates to the framed page under a timeout of its own, so the
+    ...    scope setting under test never governs the navigation.
+    Go To    ${WAIT_URL_FRAMED}    timeout=${FRAME_LOAD_TIMEOUT}
+    Wait For Framed Page
+
+Ensure Open Framed Page
+    Ensure Open Page    ${WAIT_URL_FRAMED}
+    Wait For Framed Page

--- a/atest/test/08_Scope_Tests/scope_logger.py
+++ b/atest/test/08_Scope_Tests/scope_logger.py
@@ -14,10 +14,10 @@ def log_all_scopes(
     exp_selector_prefix: Optional[str] = None,
 ):
     b: Browser = BuiltIn().get_library_instance("Browser")
-    timeout = b.scope_stack["timeout"].get()
-    retry_assertions_for = b.scope_stack["retry_assertions_for"].get()
-    strict_mode = b.scope_stack["strict_mode"].get()
-    selector_prefix = b.scope_stack["selector_prefix"].get()
+    timeout = b.timeout
+    retry_assertions_for = b.retry_assertions_for
+    strict_mode = b.strict_mode
+    selector_prefix = b.selector_prefix
 
     assert timeout == exp_timeout, (
         f"timeout: {timeout} ({type(timeout)}) != {exp_timeout} ({type(exp_timeout)})"
@@ -45,20 +45,17 @@ def log_all_scopes(
     }
 
 
-def assert_passed_duration(
-    start_time: datetime, max_duration_ms: int, delta_ms: int = 300
-) -> None:
-    now = datetime.now()
-    logger.info(
-        f"Start time: {start_time.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}, now: {now.strftime('%Y-%m-%d %H:%M:%S.%f')[:-3]}"
-    )
-    elapsed_ms = int((now - start_time).total_seconds() * 1000)
-    logger.info(
-        f"Elapsed time: {elapsed_ms}ms (max allowed: {max_duration_ms + delta_ms}ms)"
-    )
-    if elapsed_ms > max_duration_ms + delta_ms:
-        browser = BuiltIn().get_library_instance("Browser")
-        browser.take_screenshot()
+def assert_retried_for_at_least(start_time: datetime, min_duration_ms: int) -> None:
+    """Asserts an assertion keyword kept retrying for at least its budget.
+
+    A lower bound, deliberately. `with_assertion_polling` gives up only once the
+    retry budget (or the browser timeout) is spent, so a loaded CI runner can
+    make this longer but never shorter - which an upper bound cannot survive.
+    """
+    elapsed_ms = int((datetime.now() - start_time).total_seconds() * 1000)
+    logger.info(f"Retried for {elapsed_ms}ms (at least {min_duration_ms}ms expected)")
+    if elapsed_ms < min_duration_ms:
         raise AssertionError(
-            f"Elapsed time {elapsed_ms}ms exceeded maximum of {max_duration_ms + delta_ms}ms."
+            f"Retried for {elapsed_ms}ms, which is less than the "
+            f"{min_duration_ms}ms budget the scope should have given it."
         )

--- a/utest/test_tool_ci_failures.py
+++ b/utest/test_tool_ci_failures.py
@@ -3195,7 +3195,7 @@ class TestTheColumnsThatNeedNoArtifact:
         run_sql(
             db,
             "UPDATE test_result SET keyword_owner = 'scope_logger', "
-            "failing_keyword = 'Assert Passed Duration'",
+            "failing_keyword = 'Log All Scopes'",
         )
 
         ingest.recompute_keyword_locations(db, report=lambda _: None)


### PR DESCRIPTION
Instead of measuring wall clock time, which is hard in CI, get error text timeout value and see that it has correct value in it