### PR TITLE
fix: Retry a screenshot Chromium refuses outright

### DIFF
--- a/atest/test/00_Clean_Output_Dir/01_initial_import.robot
+++ b/atest/test/00_Clean_Output_Dir/01_initial_import.robot
@@ -16,6 +16,8 @@ Take Screenshot
     File Should Not Exist    ${OUTPUT DIR}/browser/screenshot/initial_screenshot.png
     File Should Not Exist    ${OUTPUT DIR}/browser/screenshot/second_screenshot.png
     File Should Not Exist    ${OUTPUT DIR}/browser/screenshot/third_screenshot.png
+    # Wait For Elements State done because without it the first capture is fail randomly on mac
+    Wait For Elements State    ${SELECTOR_PREFIX_SPACED}id=table1    stable
     ${initial_screenshot} =    Take Screenshot    initial_screenshot    fullPage=True
     VAR    ${initial_screenshot} =    ${initial_screenshot}    scope=GLOBAL
     File Should Exist    ${initial_screenshot}

--- a/atest/test/00_Clean_Output_Dir/02_second_import.robot
+++ b/atest/test/00_Clean_Output_Dir/02_second_import.robot
@@ -1,7 +1,11 @@
 *** Settings ***
-Library     Browser    retry_assertions_for=4 sec
-Library     OperatingSystem
-Resource    ../variables.resource
+Documentation
+...              If Variable \${initial_screenshot} not found, it means 01 failed before it could
+...              publish the path as global variable. Nothing is wrong in this file; look at 01.
+
+Library          Browser    retry_assertions_for=4 sec
+Library          OperatingSystem
+Resource         ../variables.resource
 
 *** Test Cases ***
 Take Screenshot

--- a/atest/test/00_Clean_Output_Dir/03_import_by_keyword.robot
+++ b/atest/test/00_Clean_Output_Dir/03_import_by_keyword.robot
@@ -1,6 +1,11 @@
 *** Settings ***
-Library     OperatingSystem
-Resource    ../variables.resource
+Documentation
+...              If Variable \${initial_screenshot} not found, it means 01 failed before it could
+...              publish the path as global variable. Nothing is wrong in this file; look at 01.
+...              If error says \${second_screenshot} is not found, then look at 02.
+
+Library          OperatingSystem
+Resource         ../variables.resource
 
 *** Test Cases ***
 Take Screenshot


### PR DESCRIPTION
Chromium intermittently answers Page.captureScreenshot with `Protocol error (Page.captureScreenshot): Unable to capture screenshot` and then takes the very same picture when asked again, so Take Screenshot was reporting a transient browser hiccup as a keyword failure.

takeScreenshot now retries once, and only on that error. Retrying a timeout here would quietly cost the caller twice the timeout they asked for, so the retry waits 250 ms, then runs inside what is left of the original budget rather than a fresh one, and is skipped when too little is left to be worth spending - with timeout 0 read as Playwright reads it, no timeout at all. If the retry fails too, the caller is told the browser refused the capture rather than that a timeout they never configured expired.

Fixes: #5237